### PR TITLE
Request Header and Response De/Serialization

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,36 +1,68 @@
 ---
-Language:        Cpp
-# BasedOnStyle:  Chromium
+Language: Cpp
 AccessModifierOffset: 0
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: true
+AlignConsecutiveBitFields:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: true
+AlignConsecutiveDeclarations:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: true
+AlignConsecutiveMacros:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: true
 AlignEscapedNewlines: Left
-AlignOperands:   false
-AlignTrailingComments: false
+AlignOperands: Align
+AlignTrailingComments:
+  Kind: Never
+  OverEmptyLines: 0
+AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: true
+AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: OnlyFirstIf
 AllowShortLoopsOnASingleLine: true
+AllowShortLambdasOnASingleLine: All
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
+  AfterClass: false
+  AfterControlStatement: MultiLine
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
   AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
+  AfterStruct: false
+  AfterUnion: false
   AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  AfterCaseLabel: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
 BreakBeforeInheritanceComma: false
@@ -39,36 +71,50 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit:     0
-CommentPragmas:  '^ IWYU pragma:'
+ColumnLimit: 0
+CommentPragmas: "^ IWYU pragma:"
+CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-DisableFormat:   false
+DisableFormat: false
 ExperimentalAutoDetectBinPacking: true
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
 IncludeCategories:
-  - Regex:           '^"'
-    Priority:        1
-  - Regex:           '^<llvm/.*>'
-    Priority:        2
-  - Regex:           '^<.*\.h>'
-    Priority:        4
-  - Regex:           '^<'
-    Priority:        3
-  - Regex:           '.\*'
-    Priority:        5
-IncludeIsMainRegex: '([-_](test|unittest))?$'
+  - Regex: ^"
+    Priority: 1
+  - Regex: ^<llvm/.*>
+    Priority: 2
+  - Regex: ^<.*\.h>
+    Priority: 4
+  - Regex: ^<
+    Priority: 3
+  - Regex: .\*
+    Priority: 5
+IncludeIsMainRegex: ([-_](test|unittest))?$
+IndentAccessModifiers: false
 IndentCaseLabels: true
-IndentWidth:     4
+IndentCaseBlocks: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: false
+IndentWidth: 4
 IndentWrappedFunctionNames: false
+InsertBraces: false
+InsertNewlineAtEOF: true
+InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
+MacroBlockBegin: ""
+MacroBlockEnd: ""
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCBlockIndentWidth: 4
@@ -81,20 +127,29 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-ReflowComments:  false
-SortIncludes:    true
+ReflowComments: false
+SortIncludes: CaseSensitive
 SpaceAfterCStyleCast: true
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros: true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesInAngles: Leave
 SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Auto
-TabWidth:        4
-UseTab:          Never
-...
+Standard: Latest
+TabWidth: 4
+UseTab: Never

--- a/example/benchmark/include/network/s3_send_receiver.hpp
+++ b/example/benchmark/include/network/s3_send_receiver.hpp
@@ -15,7 +15,6 @@
 #include <mutex>
 #include <thread>
 #include <unordered_map>
-#include <unistd.h>
 #include <aws/core/Aws.h>
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/utils/Outcome.h>
@@ -25,6 +24,7 @@
 #include <aws/s3-crt/model/GetObjectRequest.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/GetObjectRequest.h>
+#include <unistd.h>
 // ---------------------------------------------------------------------------
 // AnyBlob - Universal Cloud Object Storage Library
 // Dominik Durner, 2021

--- a/example/simple/main.cpp
+++ b/example/simple/main.cpp
@@ -1,6 +1,6 @@
 #include "cloud/provider.hpp"
-#include "network/transaction.hpp"
 #include "network/tasked_send_receiver.hpp"
+#include "network/transaction.hpp"
 #include <cstring>
 #include <iostream>
 //---------------------------------------------------------------------------

--- a/include/cloud/aws.hpp
+++ b/include/cloud/aws.hpp
@@ -79,7 +79,6 @@ class AWS : public Provider {
     /// The session secret
     thread_local static std::shared_ptr<Secret> _sessionSecret;
 
-
     public:
     /// Get instance details
     [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiver& sendReceiver) override;
@@ -131,7 +130,7 @@ class AWS : public Provider {
     [[nodiscard]] uint64_t multipartUploadSize() const override { return _multipartUploadSize; }
 
     /// Creates the generic http request and signs it
-    [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> buildRequest(AWSSigner::Request& request, std::string_view payload = "", bool initHeaders = true) const;
+    [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> buildRequest(network::HttpRequest& request, const uint8_t* bodyData = nullptr, uint64_t bodyLength = 0, bool initHeaders = true) const;
     /// Builds the http request for downloading a blob or listing the directory
     [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> getRequest(const std::string& filePath, const std::pair<uint64_t, uint64_t>& range) const override;
     /// Builds the http request for putting objects without the object data itself
@@ -149,7 +148,7 @@ class AWS : public Provider {
     /// Builds the http request for creating multipart put objects
     [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> createMultiPartRequest(const std::string& filePath) const override;
     /// Builds the http request for completing multipart put objects
-    [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> completeMultiPartRequest(const std::string& filePath, std::string_view uploadId, const std::vector<std::string>& etags) const override;
+    [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> completeMultiPartRequest(const std::string& filePath, std::string_view uploadId, const std::vector<std::string>& etags, std::string& content) const override;
     /// Builds the http request for getting the session token objects
     [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> getSessionToken(std::string_view type = "ReadWrite") const;
     /// Get the address of the server

--- a/include/cloud/aws_signer.hpp
+++ b/include/cloud/aws_signer.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <map>
+#include "network/http_request.hpp"
 #include <memory>
 #include <string>
 //---------------------------------------------------------------------------
@@ -17,40 +17,23 @@ namespace cloud {
 /// It follows the v4 docu: https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
 class AWSSigner {
     public:
-    struct Request {
-        /// The method
-        std::string method;
-        /// The type
-        std::string type;
-        /// The path - needs to be RFC 3986 conform
-        std::string path;
-        /// The queries - need to be RFC 3986 conform
-        std::map<std::string, std::string> queries;
-        /// The headers - need to be without trailing and leading whitespaces
-        std::map<std::string, std::string> headers;
-        /// The signed headers
-        std::string signedHeaders;
-        /// The payload hash
-        std::string payloadHash;
-        /// The unowned body data
-        const uint8_t* bodyData;
-        /// The unowned body length
-        uint64_t bodyLength;
-    };
-
     struct StringToSign {
         /// The canonical request
-        Request& request;
-        /// The request sha
-        std::string& requestSHA;
+        network::HttpRequest& request;
         /// The region
         std::string region;
         /// The service
         std::string service;
+        /// The request sha
+        std::string requestSHA;
+        /// The signed headers
+        std::string signedHeaders;
+        /// The payload hash
+        std::string payloadHash;
     };
 
     /// Creates the canonical request from the input
-    [[nodiscard]] static std::pair<std::string, std::string> createCanonicalRequest(Request& request);
+    static void encodeCanonicalRequest(network::HttpRequest& request, StringToSign& stringToSign, const uint8_t* bodyData = nullptr, uint64_t bodyLength = 0);
     /// Calculates the signature
     [[nodiscard]] static std::string createSignedRequest(const std::string& keyId, const std::string& secret, const StringToSign& stringToSign);
 

--- a/include/cloud/azure_signer.hpp
+++ b/include/cloud/azure_signer.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "network/http_request.hpp"
 #include <map>
 #include <memory>
 #include <string>
@@ -17,29 +18,8 @@ namespace cloud {
 /// It follows the v4 docu: https://cloud.google.com/storage/docs/access-control/signing-urls-manually
 class AzureSigner {
     public:
-    struct Request {
-        /// The method
-        std::string method;
-        /// The type
-        std::string type;
-        /// The path - needs to be RFC 3986 conform
-        std::string path;
-        /// The queries - need to be RFC 3986 conform
-        std::map<std::string, std::string> queries;
-        /// The headers - need to be without trailing and leading whitespaces
-        std::map<std::string, std::string> headers;
-        /// The signed headers
-        std::string signedHeaders;
-        /// The payload hash
-        std::string payloadHash;
-        /// The unowned body data
-        const uint8_t* bodyData;
-        /// The unowned body length
-        uint64_t bodyLength;
-    };
-
     /// Builds the signed url
-    [[nodiscard]] static std::string createSignedRequest(const std::string& serviceAccountEmail, const std::string& privateRSA, Request& request);
+    [[nodiscard]] static std::string createSignedRequest(const std::string& serviceAccountEmail, const std::string& privateRSA, network::HttpRequest& request);
 };
 //---------------------------------------------------------------------------
 }; // namespace cloud

--- a/include/cloud/gcp.hpp
+++ b/include/cloud/gcp.hpp
@@ -75,7 +75,6 @@ class GCP : public Provider {
     /// Allows multipart upload if size > 0
     [[nodiscard]] uint64_t multipartUploadSize() const override { return 128ull << 20; }
 
-
     /// Builds the http request for downloading a blob or listing the directory
     [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> getRequest(const std::string& filePath, const std::pair<uint64_t, uint64_t>& range) const override;
     /// Builds the http request for putting objects without the object data itself
@@ -84,7 +83,7 @@ class GCP : public Provider {
     [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> putRequest(const std::string& filePath, std::string_view object) const override {
         return putRequestGeneric(filePath, object, 0, "");
     }
-   // Builds the http request for deleting an objects
+    // Builds the http request for deleting an objects
     [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> deleteRequest(const std::string& filePath) const override {
         return deleteRequestGeneric(filePath, "");
     }

--- a/include/cloud/gcp.hpp
+++ b/include/cloud/gcp.hpp
@@ -92,7 +92,7 @@ class GCP : public Provider {
     /// Builds the http request for creating multipart put objects
     [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> createMultiPartRequest(const std::string& filePath) const override;
     /// Builds the http request for completing multipart put objects
-    [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> completeMultiPartRequest(const std::string& filePath, std::string_view uploadId, const std::vector<std::string>& etags) const override;
+    [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> completeMultiPartRequest(const std::string& filePath, std::string_view uploadId, const std::vector<std::string>& etags, std::string& content) const override;
 
     /// Get the address of the server
     [[nodiscard]] std::string getAddress() const override;

--- a/include/cloud/gcp_signer.hpp
+++ b/include/cloud/gcp_signer.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "network/http_request.hpp"
 #include <map>
 #include <memory>
 #include <string>
@@ -17,36 +18,17 @@ namespace cloud {
 /// It follows the v4 docu: https://cloud.google.com/storage/docs/access-control/signing-urls-manually
 class GCPSigner {
     public:
-    struct Request {
-        /// The method
-        std::string method;
-        /// The type
-        std::string type;
-        /// The path - needs to be RFC 3986 conform
-        std::string path;
-        /// The queries - need to be RFC 3986 conform
-        std::map<std::string, std::string> queries;
-        /// The headers - need to be without trailing and leading whitespaces
-        std::map<std::string, std::string> headers;
-        /// The signed headers
-        std::string signedHeaders;
-        /// The payload hash
-        std::string payloadHash;
-        /// The unowned body data
-        const uint8_t* bodyData;
-        /// The unowned body length
-        uint64_t bodyLength;
-    };
-
     struct StringToSign {
         /// The region
         std::string region;
         /// The service
         std::string service;
+        /// The signed headers
+        std::string signedHeaders;
     };
 
     /// Builds the signed url
-    [[nodiscard]] static std::string createSignedRequest(const std::string& serviceAccountEmail, const std::string& privateRSA, Request& request, const StringToSign& stringToSign);
+    [[nodiscard]] static std::string createSignedRequest(const std::string& serviceAccountEmail, const std::string& privateRSA, network::HttpRequest& request, StringToSign& stringToSign);
 };
 //---------------------------------------------------------------------------
 }; // namespace cloud

--- a/include/cloud/provider.hpp
+++ b/include/cloud/provider.hpp
@@ -106,7 +106,7 @@ class Provider {
 
     public:
     /// The destructor
-    virtual ~Provider() = default;
+    virtual ~Provider() noexcept = default;
     /// Gets the cloud provider type
     [[nodiscard]] CloudService getType() { return _type; }
     /// Is it a remote file?

--- a/include/cloud/provider.hpp
+++ b/include/cloud/provider.hpp
@@ -28,7 +28,7 @@ namespace cloud {
 //---------------------------------------------------------------------------
 /// Implements the cloud provider abstraction
 class Provider {
-public:
+    public:
     /// The remote prefixes count
     static constexpr unsigned remoteFileCount = 6;
     /// The remote prefixes
@@ -59,6 +59,8 @@ public:
         std::string endpoint = "";
         /// The port
         uint32_t port = 80;
+        /// Is zonal endpoint?
+        bool zonal = false;
     };
 
     /// Instance struct
@@ -73,8 +75,7 @@ public:
         uint64_t network;
     };
 
-
-protected:
+    protected:
     CloudService _type;
     /// Builds the http request for downloading a blob or listing a directory
     [[nodiscard]] virtual std::unique_ptr<utils::DataVector<uint8_t>> getRequest(const std::string& filePath, const std::pair<uint64_t, uint64_t>& range) const = 0;
@@ -100,8 +101,10 @@ protected:
 
     /// Initialize secret
     virtual void initSecret(network::TaskedSendReceiver& /*sendReceiver*/) {}
+    /// Get a local copy of the global secret
+    virtual void getSecret() {}
 
-public:
+    public:
     /// The destructor
     virtual ~Provider() = default;
     /// Gets the cloud provider type
@@ -120,7 +123,6 @@ public:
     [[nodiscard]] static std::string getUploadId(std::string_view body);
     /// Parse a row from csv file
     [[nodiscard]] static std::vector<std::string> parseCSVRow(std::string_view body);
-
 
     /// Create a provider (keyId is access email for GCP/Azure)
     [[nodiscard]] static std::unique_ptr<Provider> makeProvider(const std::string& filepath, bool https = true, const std::string& keyId = "", const std::string& keyFile = "", network::TaskedSendReceiver* sendReceiver = nullptr);

--- a/include/cloud/provider.hpp
+++ b/include/cloud/provider.hpp
@@ -97,7 +97,7 @@ class Provider {
     /// Builds the http request for creating multipart put objects
     [[nodiscard]] virtual std::unique_ptr<utils::DataVector<uint8_t>> createMultiPartRequest(const std::string& /*filePath*/) const;
     /// Builds the http request for completing multipart put objects
-    [[nodiscard]] virtual std::unique_ptr<utils::DataVector<uint8_t>> completeMultiPartRequest(const std::string& /*filePath*/, std::string_view /*uploadId*/, const std::vector<std::string>& /*etags*/) const;
+    [[nodiscard]] virtual std::unique_ptr<utils::DataVector<uint8_t>> completeMultiPartRequest(const std::string& /*filePath*/, std::string_view /*uploadId*/, const std::vector<std::string>& /*etags*/, std::string& /*eTagsContent*/) const;
 
     /// Initialize secret
     virtual void initSecret(network::TaskedSendReceiver& /*sendReceiver*/) {}

--- a/include/network/config.hpp
+++ b/include/network/config.hpp
@@ -21,7 +21,6 @@ struct Config {
     /// Total requests example: 100,000 Mbits / 400 Mbits = 250 Requests
     static constexpr uint64_t defaultCoreThroughput = 8000;
 
-
     /// Throughput per core in Mbit/s
     uint64_t coreThroughput;
     /// Concurrent requests to achieve coreThroughput

--- a/include/network/http_helper.hpp
+++ b/include/network/http_helper.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "network/http_response.hpp"
 #include <cstdint>
 #include <memory>
 #include <string_view>
@@ -16,17 +17,6 @@ namespace network {
 /// Implements an helper to resolve http requests
 class HttpHelper {
     public:
-    /// The protocol detected by the helper
-    enum class Protocol : uint8_t {
-        Invalid,
-        Unknown,
-        HTTP_1_0_OK,
-        HTTP_1_1_Partial,
-        HTTP_1_1_OK,
-        HTTP_1_1_Created,
-        HTTP_1_1_No_Content
-    };
-
     /// The encoding
     enum class Encoding : uint8_t {
         Unknown,
@@ -35,12 +25,12 @@ class HttpHelper {
     };
 
     struct Info {
+        /// The response header
+        HttpResponse response;
         /// The maximum length
         uint64_t length;
         /// The header length
         uint32_t headerLength;
-        /// The protocol
-        Protocol protocol;
         /// The encoding
         Encoding encoding;
     };

--- a/include/network/http_helper.hpp
+++ b/include/network/http_helper.hpp
@@ -14,7 +14,7 @@ namespace anyblob {
 namespace network {
 //---------------------------------------------------------------------------
 /// Implements an helper to resolve http requests
-class HTTPHelper {
+class HttpHelper {
     public:
     /// The protocol detected by the helper
     enum class Protocol : uint8_t {

--- a/include/network/http_message.hpp
+++ b/include/network/http_message.hpp
@@ -19,7 +19,7 @@ struct HTTPMessage : public MessageTask {
     /// The tcp settings
     IOUringSocket::TCPSettings tcpSettings;
     /// HTTP info header
-    std::unique_ptr<HTTPHelper::Info> info;
+    std::unique_ptr<HttpHelper::Info> info;
 
     /// The constructor
     HTTPMessage(OriginalMessage* sendingMessage, uint64_t chunkSize);

--- a/include/network/http_request.hpp
+++ b/include/network/http_request.hpp
@@ -46,8 +46,8 @@ struct HttpRequest {
     std::string path;
 
     /// Get the request method
-    static constexpr auto getRequestMethod(const HttpRequest& request) {
-        switch (request.method) {
+    static constexpr auto getRequestMethod(const Method& method) {
+        switch (method) {
             case Method::GET: return "GET";
             case Method::PUT: return "PUT";
             case Method::POST: return "POST";
@@ -56,8 +56,8 @@ struct HttpRequest {
         }
     }
     /// Get the request type
-    static constexpr auto getRequestType(const HttpRequest& request) {
-        switch (request.type) {
+    static constexpr auto getRequestType(const Type& type) {
+        switch (type) {
             case Type::HTTP_1_0: return "HTTP/1.0";
             case Type::HTTP_1_1: return "HTTP/1.1";
             default: return "";

--- a/include/network/http_request.hpp
+++ b/include/network/http_request.hpp
@@ -1,0 +1,73 @@
+#pragma once
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+//---------------------------------------------------------------------------
+// AnyBlob - Universal Cloud Object Storage Library
+// Dominik Durner, 2024
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+//---------------------------------------------------------------------------
+namespace anyblob {
+//---------------------------------------------------------------------------
+namespace utils {
+template <typename T>
+class DataVector;
+}
+//---------------------------------------------------------------------------
+namespace network {
+//---------------------------------------------------------------------------
+/// Implements an helper to serialize and deserialize http requests
+struct HttpRequest {
+    /// The method class
+    enum class Method : uint8_t {
+        GET,
+        PUT,
+        POST,
+        DELETE
+    };
+    enum class Type : uint8_t {
+        HTTP_1_0,
+        HTTP_1_1
+    };
+    /// The queries - need to be RFC 3986 conform
+    std::map<std::string, std::string> queries;
+    /// The headers - need to be without trailing and leading whitespaces
+    std::map<std::string, std::string> headers;
+    /// The method
+    Method method;
+    /// The type
+    Type type;
+    /// The path - needs to be RFC 3986 conform
+    std::string path;
+
+    /// Get the request method
+    static constexpr auto getRequestMethod(const HttpRequest& request) {
+        switch (request.method) {
+            case Method::GET: return "GET";
+            case Method::PUT: return "PUT";
+            case Method::POST: return "POST";
+            case Method::DELETE: return "DELETE";
+            default: return "";
+        }
+    }
+    /// Get the request type
+    static constexpr auto getRequestType(const HttpRequest& request) {
+        switch (request.type) {
+            case Type::HTTP_1_0: return "HTTP/1.0";
+            case Type::HTTP_1_1: return "HTTP/1.1";
+            default: return "";
+        }
+    }
+    /// Serialize the request
+    [[nodiscard]] static std::unique_ptr<utils::DataVector<uint8_t>> serialize(const HttpRequest& request);
+    /// Deserialize the request
+    [[nodiscard]] static HttpRequest deserialize(std::string_view data);
+};
+//---------------------------------------------------------------------------
+} // namespace network
+} // namespace anyblob

--- a/include/network/http_response.hpp
+++ b/include/network/http_response.hpp
@@ -82,6 +82,14 @@ struct HttpResponse {
             default: return "UNKNOWN";
         }
     }
+    /// Check for successful operation 2xx operations
+    static constexpr auto checkSuccess(const Code& code) {
+        return (code == Code::OK_200 || code == Code::CREATED_201 || code == Code::NO_CONTENT_204 || code == Code::PARTIAL_CONTENT_206);
+    }
+    /// Check if the result has no content
+    static constexpr auto withoutContent(const Code& code) {
+        return code == Code::NO_CONTENT_204;
+    }
     /// Deserialize the response
     [[nodiscard]] static HttpResponse deserialize(std::string_view data);
 };

--- a/include/network/http_response.hpp
+++ b/include/network/http_response.hpp
@@ -54,7 +54,7 @@ struct HttpResponse {
     Type type;
 
     /// Get the request method
-    static constexpr auto getResponseCode(const Code& code) noexcept {
+    static constexpr std::string_view getResponseCode(const Code& code) noexcept {
         switch (code) {
             case Code::OK_200: return "200 OK";
             case Code::CREATED_201: return "201 Created";
@@ -75,7 +75,7 @@ struct HttpResponse {
         }
     }
     /// Get the request type
-    static constexpr auto getResponseType(const Type& type) noexcept {
+    static constexpr std::string_view getResponseType(const Type& type) noexcept {
         switch (type) {
             case Type::HTTP_1_0: return "HTTP/1.0";
             case Type::HTTP_1_1: return "HTTP/1.1";

--- a/include/network/http_response.hpp
+++ b/include/network/http_response.hpp
@@ -1,0 +1,90 @@
+#pragma once
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+//---------------------------------------------------------------------------
+// AnyBlob - Universal Cloud Object Storage Library
+// Dominik Durner, 2024
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+//---------------------------------------------------------------------------
+namespace anyblob {
+//---------------------------------------------------------------------------
+namespace utils {
+template <typename T>
+class DataVector;
+}
+//---------------------------------------------------------------------------
+namespace network {
+//---------------------------------------------------------------------------
+/// Implements an helper to deserialize http responses
+struct HttpResponse {
+    /// Important error codes
+    enum class Code : uint8_t {
+        OK_200,
+        CREATED_201,
+        NO_CONTENT_204,
+        PARTIAL_CONTENT_206,
+        BAD_REQUEST_400,
+        UNAUTHORIZED_401,
+        FORBIDDEN_403,
+        NOT_FOUND_404,
+        CONFLICT_409,
+        LENGTH_REQUIRED_411,
+        RANGE_NOT_SATISFIABLE_416,
+        TOO_MANY_REQUESTS_429,
+        INTERNAL_SERVER_ERROR_500,
+        SERVICE_UNAVAILABLE_503,
+        SLOW_DOWN_503,
+        UNKNOWN = 255
+    };
+    enum class Type : uint8_t {
+        HTTP_1_0,
+        HTTP_1_1
+    };
+    /// The headers - need to be without trailing and leading whitespaces
+    std::map<std::string, std::string> headers;
+    /// The method
+    Code code;
+    /// The type
+    Type type;
+
+    /// Get the request method
+    static constexpr auto getResponseCode(const Code& code) noexcept {
+        switch (code) {
+            case Code::OK_200: return "200 OK";
+            case Code::CREATED_201: return "201 Created";
+            case Code::NO_CONTENT_204: return "204 No Content";
+            case Code::PARTIAL_CONTENT_206: return "206 Partial Content";
+            case Code::BAD_REQUEST_400: return "400 Bad Request";
+            case Code::UNAUTHORIZED_401: return "401 Unauthorized";
+            case Code::FORBIDDEN_403: return "403 Forbidden";
+            case Code::NOT_FOUND_404: return "404 Not Found";
+            case Code::CONFLICT_409: return "409 Conflict";
+            case Code::LENGTH_REQUIRED_411: return "411 Length Required";
+            case Code::RANGE_NOT_SATISFIABLE_416: return "416 Range Not Satisfiable";
+            case Code::TOO_MANY_REQUESTS_429: return "429 Too Many Requests";
+            case Code::INTERNAL_SERVER_ERROR_500: return "500 Internal Server Error";
+            case Code::SERVICE_UNAVAILABLE_503: return "503 Service Unavailable";
+            case Code::SLOW_DOWN_503: return "503 Slow Down";
+            default: return "UNKNOWN";
+        }
+    }
+    /// Get the request type
+    static constexpr auto getResponseType(const Type& type) noexcept {
+        switch (type) {
+            case Type::HTTP_1_0: return "HTTP/1.0";
+            case Type::HTTP_1_1: return "HTTP/1.1";
+            default: return "UNKNOWN";
+        }
+    }
+    /// Deserialize the response
+    [[nodiscard]] static HttpResponse deserialize(std::string_view data);
+};
+//---------------------------------------------------------------------------
+} // namespace network
+} // namespace anyblob

--- a/include/network/io_uring_socket.hpp
+++ b/include/network/io_uring_socket.hpp
@@ -103,14 +103,14 @@ class IOUringSocket {
 
     public:
     /// The IO Uring Socket Constructor
-    IOUringSocket(uint32_t entries, int32_t flags = 0);
+    explicit IOUringSocket(uint32_t entries, int32_t flags = 0);
     /// The destructor
     ~IOUringSocket();
 
     /// Creates a new socket connection
-    [[nodiscard]] int32_t connect(std::string hostname, uint32_t port, TCPSettings& tcpSettings, int retryLimit = 16);
+    [[nodiscard]] int32_t connect(std::string hostname, uint32_t port, const TCPSettings& tcpSettings, int retryLimit = 16);
     /// Disconnects the socket
-    void disconnect(int32_t fd, std::string hostname = "", uint32_t port = 0, TCPSettings* tcpSettings = nullptr, uint64_t bytes = 0, bool forceShutdown = false);
+    void disconnect(int32_t fd, std::string hostname = "", uint32_t port = 0, const TCPSettings* tcpSettings = nullptr, uint64_t bytes = 0, bool forceShutdown = false);
 
     /// Add resolver
     void addResolver(const std::string& hostname, std::unique_ptr<Resolver> resolver);
@@ -137,7 +137,7 @@ class IOUringSocket {
     /// Wait for a new cqe event arriving
     void wait();
     /// Checks for a timeout
-    bool checkTimeout(int fd, TCPSettings& settings);
+    bool checkTimeout(int fd, const TCPSettings& settings);
 
     /// Submit uring to the kernel and return the number of submitted entries
     int32_t submit();

--- a/include/network/message_result.hpp
+++ b/include/network/message_result.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "network/http_helper.hpp"
 #include <atomic>
 #include <memory>
 #include <string_view>
@@ -63,10 +64,8 @@ class MessageResult {
     protected:
     /// The data
     std::unique_ptr<utils::DataVector<uint8_t>> dataVector;
-    /// The size of the result; the size of the message body
-    uint64_t size;
-    /// The offset of the result; the start after the message header
-    uint64_t offset;
+    /// The http response header info
+    std::unique_ptr<HttpHelper::Info> response;
     /// The error response
     const MessageResult* originError;
     /// The failure code
@@ -101,7 +100,9 @@ class MessageResult {
     /// Get the failure code
     [[nodiscard]] uint16_t getFailureCode() const;
     /// Get the error response (incl. header)
-    [[nodiscard]] std::string_view getError() const;
+    [[nodiscard]] std::string_view getErrorResponse() const;
+    /// Get the error response code
+    [[nodiscard]] std::string_view getResponseCode() const;
     /// Is the data owned by this object
     [[nodiscard]] bool owned() const;
     /// Was the request successful

--- a/include/network/message_result.hpp
+++ b/include/network/message_result.hpp
@@ -80,7 +80,7 @@ class MessageResult {
     /// The constructor with buffer input
     MessageResult(uint8_t* data, uint64_t size);
     /// The constructor with buffer input
-    MessageResult(utils::DataVector<uint8_t>* dataVector);
+    explicit MessageResult(utils::DataVector<uint8_t>* dataVector);
 
     /// Get the result
     [[nodiscard]] const std::string_view getResult() const;

--- a/include/network/message_task.hpp
+++ b/include/network/message_task.hpp
@@ -59,8 +59,7 @@ struct MessageTask {
         std::string_view s(reinterpret_cast<char*>(sendingMessage->message->data()), sendingMessage->message->size());
         if (s.find("HTTP") != std::string_view::npos && sendingMessage->port == 443) {
             return std::make_unique<HTTPSMessage>(sendingMessage, context, std::forward<Args>(args)...);
-        }
-        else if (s.find("HTTP") != std::string_view::npos) {
+        } else if (s.find("HTTP") != std::string_view::npos) {
             return std::make_unique<HTTPMessage>(sendingMessage, std::forward<Args>(args)...);
         }
         return nullptr;

--- a/include/network/original_message.hpp
+++ b/include/network/original_message.hpp
@@ -27,22 +27,22 @@ struct OriginalMessage {
     /// The result
     MessageResult result;
 
-    /// The hostname
-    std::string hostname;
-    /// The port
-    uint32_t port;
-
-    /// Optional trace info
-    uint64_t traceId;
-
     /// If it is a put request store the additional data
     /// The raw data ptr for put requests
     const uint8_t* putData;
     /// The length
     uint64_t putLength;
 
+    /// Optional trace info
+    uint64_t traceId;
+
+    /// The hostname
+    std::string hostname;
+    /// The port
+    uint32_t port;
+
     /// The constructor
-    OriginalMessage(std::unique_ptr<utils::DataVector<uint8_t>> message, std::string_view hostname, uint32_t port, uint8_t* receiveBuffer = nullptr, uint64_t bufferSize = 0, uint64_t traceId = 0) : message(std::move(message)), result(receiveBuffer, bufferSize), hostname(hostname), port(port), traceId(traceId), putData(nullptr), putLength() {}
+    OriginalMessage(std::unique_ptr<utils::DataVector<uint8_t>> message, std::string_view hostname, uint32_t port, uint8_t* receiveBuffer = nullptr, uint64_t bufferSize = 0, uint64_t traceId = 0) : message(std::move(message)), result(receiveBuffer, bufferSize), putData(nullptr), putLength(), traceId(traceId), hostname(hostname), port(port) {}
 
     /// The destructor
     virtual ~OriginalMessage() = default;

--- a/include/network/tasked_send_receiver.hpp
+++ b/include/network/tasked_send_receiver.hpp
@@ -64,7 +64,7 @@ class TaskedSendReceiverGroup {
 
     public:
     /// Initializes the global submissions and completions
-    TaskedSendReceiverGroup(unsigned chunkSize = 64u * 1024, uint64_t submissions = std::thread::hardware_concurrency() * submissionPerCore, uint64_t reuse = 0);
+    explicit TaskedSendReceiverGroup(unsigned chunkSize = 64u * 1024, uint64_t submissions = std::thread::hardware_concurrency() * submissionPerCore, uint64_t reuse = 0);
     /// Destructor
     ~TaskedSendReceiverGroup();
 
@@ -121,7 +121,7 @@ class TaskedSendReceiver {
 
     public:
     /// The constructor
-    TaskedSendReceiver(TaskedSendReceiverGroup& group);
+    explicit TaskedSendReceiver(TaskedSendReceiverGroup& group);
 
     /// Get the group
     [[nodiscard]] const TaskedSendReceiverGroup* getGroup() const { return &_group; }
@@ -157,7 +157,7 @@ class TaskedSendReceiver {
     /// Submits queue and waits for result
     void sendReceive(bool local = false, bool oneQueueInvocation = true);
     /// Connect to the socket return fd
-    [[nodiscard]] int32_t connect(std::string hostname, uint32_t port);
+    [[nodiscard]] int32_t connect(const std::string& hostname, uint32_t port);
     /// Submits the queue
     [[nodiscard]] int32_t submitRequests();
 
@@ -176,7 +176,7 @@ class TaskedSendReceiverHandle {
     /// Default constructor is deleted
     TaskedSendReceiverHandle() = delete;
     /// Consturctor
-    TaskedSendReceiverHandle(TaskedSendReceiverGroup* group);
+    explicit TaskedSendReceiverHandle(TaskedSendReceiverGroup* group);
     /// Delete copy
     TaskedSendReceiverHandle(TaskedSendReceiverHandle& other) = delete;
     /// Delete copy assignment

--- a/include/network/tls_context.hpp
+++ b/include/network/tls_context.hpp
@@ -1,9 +1,9 @@
 #pragma once
-#include <memory>
 #include <array>
+#include <memory>
 #include <unordered_map>
-#include <openssl/types.h>
 #include <openssl/ssl.h>
+#include <openssl/types.h>
 //---------------------------------------------------------------------------
 // AnyBlob - Universal Cloud Object Storage Library
 // Dominik Durner, 2023
@@ -28,7 +28,7 @@ class TLSContext {
     /// The cache mask
     static constexpr uint64_t cacheMask = (~0ull) >> (64 - cachePower);
     /// The session cache
-    std::array<std::pair<uint64_t,  SSL_SESSION*>, 1ull << cachePower> _sessionCache;
+    std::array<std::pair<uint64_t, SSL_SESSION*>, 1ull << cachePower> _sessionCache;
 
     public:
     /// The constructor

--- a/include/network/transaction.hpp
+++ b/include/network/transaction.hpp
@@ -301,7 +301,7 @@ class Transaction {
         message_vector_type::iterator it;
 
         /// Constructor with iterator
-        constexpr Iterator(const message_vector_type::iterator& it) { this->it = it; };
+        explicit constexpr Iterator(const message_vector_type::iterator& it) { this->it = it; };
         /// Copy constructor
         constexpr Iterator(const Iterator& it) { this->it = it.it; }
         /// Delete default constructor
@@ -349,7 +349,7 @@ class Transaction {
         message_vector_type::const_iterator it;
 
         /// Constructor with iterator
-        constexpr ConstIterator(const message_vector_type::const_iterator& it) { this->it = it; }
+        explicit constexpr ConstIterator(const message_vector_type::const_iterator& it) { this->it = it; }
         /// Copy constructor
         constexpr ConstIterator(const ConstIterator& it) { this->it = it.it; }
         /// Delete default constructor

--- a/include/network/transaction.hpp
+++ b/include/network/transaction.hpp
@@ -205,7 +205,7 @@ class Transaction {
         _multipartUploads.emplace_back(parts);
         auto position = _multipartUploads.size() - 1;
 
-        auto uploadMessages = [&callback, position, parts, data, remotePath, traceId, splitSize, size, this](network::MessageResult& initalRequestResult) {
+        auto uploadMessages = [callback = std::forward<Callback>(callback), position, parts, data, remotePath, traceId, splitSize, size, this](network::MessageResult& initalRequestResult) {
             if (!initalRequestResult.success()) {
                 _completedMultiparts++;
                 return;
@@ -232,7 +232,7 @@ class Transaction {
                                     initalRequestResult.originError = &result;
                                 }
                                 _completedMultiparts++;
-                                std::forward<Callback>(callback)(initalRequestResult);
+                                callback(initalRequestResult);
                             };
                             auto originalMsg = makeCallbackMessage(std::move(finished), _provider->completeMultiPartRequest(remotePath, _multipartUploads[position].uploadId, _multipartUploads[position].eTags, *content), _provider->getAddress(), _provider->getPort(), nullptr, 0, traceId);
                             originalMsg->setPutRequestData(reinterpret_cast<const uint8_t*>(content->data()), content->size());
@@ -242,7 +242,7 @@ class Transaction {
                                 initalRequestResult.state = network::MessageState::Cancelled;
                                 initalRequestResult.originError = &_multipartUploads[position].messages[_multipartUploads[position].errorMessageId]->result;
                                 _completedMultiparts++;
-                                std::forward<Callback>(callback)(initalRequestResult);
+                                callback(initalRequestResult);
                             };
                             auto originalMsg = makeCallbackMessage(std::move(finished), _provider->deleteRequestGeneric(remotePath, _multipartUploads[position].uploadId), _provider->getAddress(), _provider->getPort(), nullptr, 0, traceId);
                             _multipartUploads[position].messages[parts] = std::move(originalMsg);

--- a/include/utils/data_vector.hpp
+++ b/include/utils/data_vector.hpp
@@ -30,10 +30,10 @@ class DataVector {
 
     public:
     /// Constructor
-    constexpr DataVector() : _capacity(0), _size(0) {}
+    constexpr DataVector() : _capacity(0), _size(0), _data(nullptr) {}
 
     /// Constructor with size
-    constexpr DataVector(uint64_t cap) : _capacity(0), _size(0) {
+    explicit constexpr DataVector(uint64_t cap) : _capacity(0), _size(0), _data(nullptr) {
         resize(cap);
     }
 
@@ -45,7 +45,7 @@ class DataVector {
     }
 
     /// Constructor from other pointers
-    constexpr DataVector(T* start, T* end) : _capacity(0), _size(0) {
+    constexpr DataVector(const T* start, const T* end) : _capacity(0), _size(0) {
         assert(end - start >= 0);
         resize(static_cast<uint64_t>(end - start));
         std::memcpy(data(), start, size() * sizeof(T));

--- a/include/utils/load_tracker.hpp
+++ b/include/utils/load_tracker.hpp
@@ -107,8 +107,8 @@ class LoadTracker {
     /// Get the active cpu times
     static constexpr size_t getActiveTime(const CPUData& e) {
         return e.times[static_cast<uint8_t>(CPUStates::S_USER)] + e.times[static_cast<uint8_t>(CPUStates::S_NICE)] +
-            e.times[static_cast<uint8_t>(CPUStates::S_SYSTEM)] + e.times[static_cast<uint8_t>(CPUStates::S_IRQ)] +
-            e.times[static_cast<uint8_t>(CPUStates::S_SOFTIRQ)] + e.times[static_cast<uint8_t>(CPUStates::S_STEAL)];
+               e.times[static_cast<uint8_t>(CPUStates::S_SYSTEM)] + e.times[static_cast<uint8_t>(CPUStates::S_IRQ)] +
+               e.times[static_cast<uint8_t>(CPUStates::S_SOFTIRQ)] + e.times[static_cast<uint8_t>(CPUStates::S_STEAL)];
     }
 
     /// Write stats as csv

--- a/include/utils/ring_buffer.hpp
+++ b/include/utils/ring_buffer.hpp
@@ -68,7 +68,7 @@ class RingBuffer {
 
     /// Insert a tuple into buffer
     template <bool wait = false>
-    [[ nodiscard ]] constexpr uint64_t insert(T tuple) {
+    [[nodiscard]] constexpr uint64_t insert(T tuple) {
         while (true) {
             std::unique_lock lock(_insert.mutex);
             auto seenHead = _seen.commited.load(std::memory_order_acquire);
@@ -86,7 +86,7 @@ class RingBuffer {
 
     /// Insert a span into buffer
     template <bool wait = false>
-    [[ nodiscard ]] constexpr uint64_t insertAll(std::span<T> tuples) {
+    [[nodiscard]] constexpr uint64_t insertAll(std::span<T> tuples) {
         while (true) {
             std::unique_lock lock(_insert.mutex);
             auto seenHead = _seen.commited.load();
@@ -108,7 +108,7 @@ class RingBuffer {
 
     /// Consume from buffer
     template <bool wait = false>
-    [[ nodiscard ]] constexpr std::optional<T> consume() {
+    [[nodiscard]] constexpr std::optional<T> consume() {
         while (true) {
             std::unique_lock lock(_seen.mutex);
             auto curInsert = _insert.commited.load(std::memory_order_acquire);
@@ -125,7 +125,7 @@ class RingBuffer {
     }
 
     /// Check if empty
-    [[ nodiscard ]] constexpr bool empty() const {
+    [[nodiscard]] constexpr bool empty() const {
         return !(_insert.commited.load(std::memory_order_acquire) - _seen.commited.load(std::memory_order_acquire));
     }
 };

--- a/include/utils/ring_buffer.hpp
+++ b/include/utils/ring_buffer.hpp
@@ -64,7 +64,7 @@ class RingBuffer {
 
     public:
     /// The constructor
-    constexpr RingBuffer(uint64_t size) : _buffer(new T[size]()), _size(size) {}
+    constexpr explicit RingBuffer(uint64_t size) : _buffer(new T[size]()), _size(size) {}
 
     /// Insert a tuple into buffer
     template <bool wait = false>

--- a/include/utils/unordered_map.hpp
+++ b/include/utils/unordered_map.hpp
@@ -99,19 +99,19 @@ class UnorderedMap {
         }
 
         /// Equality operator
-        [[ nodiscard ]] constexpr bool operator==(const Iterator& rhs) const {
+        [[nodiscard]] constexpr bool operator==(const Iterator& rhs) const {
             return (_tableBucket == rhs._tableBucket) && (_valueBucket == rhs._valueBucket);
         }
         /// Non equality operator
-        [[ nodiscard ]] constexpr bool operator!=(const Iterator& rhs) const {
+        [[nodiscard]] constexpr bool operator!=(const Iterator& rhs) const {
             return (_tableBucket != rhs._tableBucket) || (_valueBucket != rhs._valueBucket);
         }
         /// Get the value bucket reference
-        [[ nodiscard ]] constexpr std::pair<Key, Value>& operator*() const {
+        [[nodiscard]] constexpr std::pair<Key, Value>& operator*() const {
             return _valueBucket->keyValue;
         }
         /// Get the value bucket pointer
-        [[ nodiscard ]] constexpr std::pair<Key, Value>* operator->() const {
+        [[nodiscard]] constexpr std::pair<Key, Value>* operator->() const {
             return &_valueBucket->keyValue;
         }
 
@@ -139,14 +139,14 @@ class UnorderedMap {
     }
 
     /// The non-const begin iterator
-    [[ nodiscard ]] constexpr Iterator begin() { return Iterator(_map[0].get()); }
+    [[nodiscard]] constexpr Iterator begin() { return Iterator(_map[0].get()); }
     /// The non-const end iterator
-    [[ nodiscard ]] constexpr Iterator end() { return Iterator(); }
+    [[nodiscard]] constexpr Iterator end() { return Iterator(); }
 
     /// Returns the number of buckets
-    [[ nodiscard ]] constexpr size_t buckets() const { return _map.size(); }
+    [[nodiscard]] constexpr size_t buckets() const { return _map.size(); }
     /// Returns the size of the unordered map
-    [[ nodiscard ]] constexpr size_t size() const { return _size; }
+    [[nodiscard]] constexpr size_t size() const { return _size; }
 
     /// Insert element, returns iterator
     template <class K, class V>
@@ -186,7 +186,7 @@ class UnorderedMap {
 
     /// Erase element
     template <class K>
-    [[ nodiscard ]] constexpr bool erase(K&& key) {
+    [[nodiscard]] constexpr bool erase(K&& key) {
         auto position = Hash{}(key) % buckets();
         std::unique_lock lock(_map[position]->sharedMutex);
         auto* chain = &_map[position]->chain;
@@ -202,7 +202,7 @@ class UnorderedMap {
     }
 
     /// Erase element from iterator
-    [[ nodiscard ]] constexpr bool erase(Iterator it) {
+    [[nodiscard]] constexpr bool erase(Iterator it) {
         auto key = it->first;
         it.release();
         return erase(std::move(key));
@@ -210,7 +210,7 @@ class UnorderedMap {
 
     /// Find element, returns iterator
     template <class K>
-    [[ nodiscard ]] constexpr Iterator find(K&& key) {
+    [[nodiscard]] constexpr Iterator find(K&& key) {
         auto position = Hash{}(key) % buckets();
         std::shared_lock lock(_map[position]->sharedMutex);
         auto* chain = &_map[position]->chain;

--- a/src/cloud/aws.cpp
+++ b/src/cloud/aws.cpp
@@ -315,9 +315,9 @@ unique_ptr<utils::DataVector<uint8_t>> AWS::buildRequest(network::HttpRequest& r
 
     AWSSigner::StringToSign stringToSign = {.request = request, .region = _settings.region, .service = "s3", .requestSHA = "", .signedHeaders = "", .payloadHash = ""};
     AWSSigner::encodeCanonicalRequest(request, stringToSign, bodyData, bodyLength);
-    string httpHeader = network::HttpRequest::getRequestMethod(request);
+    string httpHeader = network::HttpRequest::getRequestMethod(request.method);
     httpHeader += " ";
-    httpHeader += AWSSigner::createSignedRequest(secret->keyId, secret->secret, stringToSign) + " " + network::HttpRequest::getRequestType(request) + "\r\n";
+    httpHeader += AWSSigner::createSignedRequest(secret->keyId, secret->secret, stringToSign) + " " + network::HttpRequest::getRequestType(request.type) + "\r\n";
     for (auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
     httpHeader += "\r\n";

--- a/src/cloud/aws_resolver.cpp
+++ b/src/cloud/aws_resolver.cpp
@@ -55,7 +55,6 @@ unsigned AWSResolver::resolve(string hostname, string port, bool& oldAddress)
             } else {
                 char ipv4[INET_ADDRSTRLEN];
                 inet_ntop(AF_INET, &p->sin_addr, ipv4, INET_ADDRSTRLEN);
-                string ip(ipv4);
                 string cmd = "timeout 0.01 ping -s 1473 -D " + string(ipv4) + " -c 1 >>/dev/null 2>>/dev/null";
                 auto res = system(cmd.c_str());
                 if (!res) {

--- a/src/cloud/aws_signer.cpp
+++ b/src/cloud/aws_signer.cpp
@@ -55,7 +55,6 @@ void AWSSigner::encodeCanonicalRequest(network::HttpRequest& request, StringToSi
             request.headers.emplace("Content-MD5", encodedResult);
         }
     } else {
-        string unsignedPayload = "UNSIGNED-PAYLOAD";
         stringToSign.payloadHash = "UNSIGNED-PAYLOAD";
         request.headers.emplace("x-amz-content-sha256", stringToSign.payloadHash);
     }
@@ -70,7 +69,7 @@ void AWSSigner::encodeCanonicalRequest(network::HttpRequest& request, StringToSi
             sorted.emplace(val, it->second);
             ++it;
         }
-        for (auto& h : sorted)
+        for (const auto& h : sorted)
             requestStream << h.first << ":" << h.second << "\n";
     }
     requestStream << "\n";

--- a/src/cloud/aws_signer.cpp
+++ b/src/cloud/aws_signer.cpp
@@ -24,7 +24,7 @@ void AWSSigner::encodeCanonicalRequest(network::HttpRequest& request, StringToSi
 {
     stringstream requestStream;
     // Step 1, canonicalize request method
-    requestStream << network::HttpRequest::getRequestMethod(request) << "\n";
+    requestStream << network::HttpRequest::getRequestMethod(request.method) << "\n";
 
     // Step 2, canonicalize request path; assume that path is RFC 3986 conform
     if (request.path.empty())

--- a/src/cloud/azure.cpp
+++ b/src/cloud/azure.cpp
@@ -86,7 +86,7 @@ string Azure::getRegion(network::TaskedSendReceiver& sendReceiver)
     string needle = "\"location\" : \"";
     auto pos = s.find(needle);
     if (pos == s.npos)
-        throw;
+        throw runtime_error("Azure Region: No location found.");
     pos += needle.length();
     auto end = s.find("\"", pos);
     auto region = s.substr(pos, end - pos);
@@ -116,7 +116,7 @@ unique_ptr<utils::DataVector<uint8_t>> Azure::getRequest(const string& filePath,
     httpHeader += " " + request.path + " ";
     httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
-    for (auto& h : request.headers)
+    for (const auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
     httpHeader += "\r\n";
 
@@ -144,7 +144,7 @@ unique_ptr<utils::DataVector<uint8_t>> Azure::putRequest(const string& filePath,
     httpHeader += " " + request.path + " ";
     httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
-    for (auto& h : request.headers)
+    for (const auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
     httpHeader += "\r\n";
 
@@ -169,7 +169,7 @@ unique_ptr<utils::DataVector<uint8_t>> Azure::deleteRequest(const string& filePa
     httpHeader += " " + request.path + " ";
     httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
-    for (auto& h : request.headers)
+    for (const auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
     httpHeader += "\r\n";
 

--- a/src/cloud/azure.cpp
+++ b/src/cloud/azure.cpp
@@ -5,6 +5,7 @@
 #include "network/tasked_send_receiver.hpp"
 #include "network/resolver.hpp"
 #include "utils/data_vector.hpp"
+#include <algorithm>
 #include <chrono>
 #include <iomanip>
 #include <sstream>
@@ -51,8 +52,8 @@ Provider::Instance Azure::getInstanceDetails(network::TaskedSendReceiver& sendRe
 {
     auto message = downloadInstanceInfo();
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), getIAMAddress(), getIAMPort());
-    sendReceiver.send(originalMsg.get());
-    sendReceiver.process();
+    sendReceiver.sendSync(originalMsg.get());
+    sendReceiver.processSync();
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HTTPHelper::Info> infoPtr;
     auto s = network::HTTPHelper::retrieveContent(content.cdata(), content.size(), infoPtr);
@@ -76,8 +77,8 @@ string Azure::getRegion(network::TaskedSendReceiver& sendReceiver)
 {
     auto message = downloadInstanceInfo();
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), getIAMAddress(), getIAMPort());
-    sendReceiver.send(originalMsg.get());
-    sendReceiver.process();
+    sendReceiver.sendSync(originalMsg.get());
+    sendReceiver.processSync();
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HTTPHelper::Info> infoPtr;
     auto s = network::HTTPHelper::retrieveContent(content.cdata(), content.size(), infoPtr);

--- a/src/cloud/azure.cpp
+++ b/src/cloud/azure.cpp
@@ -112,9 +112,9 @@ unique_ptr<utils::DataVector<uint8_t>> Azure::getRequest(const string& filePath,
 
     request.path = AzureSigner::createSignedRequest(_secret->accountName, _secret->privateKey, request);
 
-    string httpHeader = network::HttpRequest::getRequestMethod(request);
+    string httpHeader = network::HttpRequest::getRequestMethod(request.method);
     httpHeader += " " + request.path + " ";
-    httpHeader += network::HttpRequest::getRequestType(request);
+    httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
     for (auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
@@ -140,9 +140,9 @@ unique_ptr<utils::DataVector<uint8_t>> Azure::putRequest(const string& filePath,
 
     request.path = AzureSigner::createSignedRequest(_secret->accountName, _secret->privateKey, request);
 
-    string httpHeader = network::HttpRequest::getRequestMethod(request);
+    string httpHeader = network::HttpRequest::getRequestMethod(request.method);
     httpHeader += " " + request.path + " ";
-    httpHeader += network::HttpRequest::getRequestType(request);
+    httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
     for (auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
@@ -165,9 +165,9 @@ unique_ptr<utils::DataVector<uint8_t>> Azure::deleteRequest(const string& filePa
 
     request.path = AzureSigner::createSignedRequest(_secret->accountName, _secret->privateKey, request);
 
-    string httpHeader = network::HttpRequest::getRequestMethod(request);
+    string httpHeader = network::HttpRequest::getRequestMethod(request.method);
     httpHeader += " " + request.path + " ";
-    httpHeader += network::HttpRequest::getRequestType(request);
+    httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
     for (auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";

--- a/src/cloud/azure_signer.cpp
+++ b/src/cloud/azure_signer.cpp
@@ -25,7 +25,7 @@ string AzureSigner::createSignedRequest(const string& accountName, const string&
 
     stringstream requestStream;
     // canonicalize request method
-    requestStream << network::HttpRequest::getRequestMethod(request) << "\n";
+    requestStream << network::HttpRequest::getRequestMethod(request.method) << "\n";
 
     // Set the version
     request.headers.emplace("x-ms-version", "2015-02-21");

--- a/src/cloud/azure_signer.cpp
+++ b/src/cloud/azure_signer.cpp
@@ -18,14 +18,14 @@ namespace cloud {
 //---------------------------------------------------------------------------
 using namespace std;
 //---------------------------------------------------------------------------
-string AzureSigner::createSignedRequest(const string& accountName, const string& privateRSA, Request& request)
+string AzureSigner::createSignedRequest(const string& accountName, const string& privateRSA, network::HttpRequest& request)
 // Creates the canonical request
 {
     auto decodedKey = utils::base64Decode(reinterpret_cast<const uint8_t*>(privateRSA.data()), privateRSA.size());
 
     stringstream requestStream;
     // canonicalize request method
-    requestStream << request.method << "\n";
+    requestStream << network::HttpRequest::getRequestMethod(request) << "\n";
 
     // Set the version
     request.headers.emplace("x-ms-version", "2015-02-21");

--- a/src/cloud/gcp.cpp
+++ b/src/cloud/gcp.cpp
@@ -94,9 +94,9 @@ unique_ptr<utils::DataVector<uint8_t>> GCP::getRequest(const string& filePath, c
     GCPSigner::StringToSign stringToSign = {.region = _settings.region, .service = "storage", .signedHeaders = ""};
     request.path = GCPSigner::createSignedRequest(_secret->serviceAccountEmail, _secret->privateKey, request, stringToSign);
 
-    string httpHeader = network::HttpRequest::getRequestMethod(request);
+    string httpHeader = network::HttpRequest::getRequestMethod(request.method);
     httpHeader += " " + request.path + " ";
-    httpHeader += network::HttpRequest::getRequestType(request);
+    httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
     for (auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
@@ -129,9 +129,9 @@ unique_ptr<utils::DataVector<uint8_t>> GCP::putRequestGeneric(const string& file
     GCPSigner::StringToSign stringToSign = {.region = _settings.region, .service = "storage", .signedHeaders = ""};
     request.path = GCPSigner::createSignedRequest(_secret->serviceAccountEmail, _secret->privateKey, request, stringToSign);
 
-    string httpHeader = network::HttpRequest::getRequestMethod(request);
+    string httpHeader = network::HttpRequest::getRequestMethod(request.method);
     httpHeader += " " + request.path + " ";
-    httpHeader += network::HttpRequest::getRequestType(request);
+    httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
     for (auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
@@ -160,9 +160,9 @@ unique_ptr<utils::DataVector<uint8_t>> GCP::deleteRequestGeneric(const string& f
     GCPSigner::StringToSign stringToSign = {.region = _settings.region, .service = "storage", .signedHeaders = ""};
     request.path = GCPSigner::createSignedRequest(_secret->serviceAccountEmail, _secret->privateKey, request, stringToSign);
 
-    string httpHeader = network::HttpRequest::getRequestMethod(request);
+    string httpHeader = network::HttpRequest::getRequestMethod(request.method);
     httpHeader += " " + request.path + " ";
-    httpHeader += network::HttpRequest::getRequestType(request);
+    httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
     for (auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
@@ -188,9 +188,9 @@ unique_ptr<utils::DataVector<uint8_t>> GCP::createMultiPartRequest(const string&
     GCPSigner::StringToSign stringToSign = {.region = _settings.region, .service = "storage", .signedHeaders = ""};
     request.path = GCPSigner::createSignedRequest(_secret->serviceAccountEmail, _secret->privateKey, request, stringToSign);
 
-    string httpHeader = network::HttpRequest::getRequestMethod(request);
+    string httpHeader = network::HttpRequest::getRequestMethod(request.method);
     httpHeader += " " + request.path + " ";
-    httpHeader += network::HttpRequest::getRequestType(request);
+    httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
     for (auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
@@ -227,9 +227,9 @@ unique_ptr<utils::DataVector<uint8_t>> GCP::completeMultiPartRequest(const strin
     GCPSigner::StringToSign stringToSign = {.region = _settings.region, .service = "storage", .signedHeaders = ""};
     request.path = GCPSigner::createSignedRequest(_secret->serviceAccountEmail, _secret->privateKey, request, stringToSign);
 
-    string httpHeaderMessage = network::HttpRequest::getRequestMethod(request);
+    string httpHeaderMessage = network::HttpRequest::getRequestMethod(request.method);
     httpHeaderMessage += " " + request.path + " ";
-    httpHeaderMessage += network::HttpRequest::getRequestType(request);
+    httpHeaderMessage += network::HttpRequest::getRequestType(request.type);
     httpHeaderMessage += "\r\n";
 
     for (auto& h : request.headers)

--- a/src/cloud/gcp.cpp
+++ b/src/cloud/gcp.cpp
@@ -34,7 +34,6 @@ static string buildAMZTimestamp()
 unique_ptr<utils::DataVector<uint8_t>> GCP::downloadInstanceInfo(const string& info)
 // Builds the info http request
 {
-    string protocol = "http://";
     string httpHeader = "GET /computeMetadata/v1/instance/" + info + " HTTP/1.1\r\nHost: ";
     httpHeader += getIAMAddress();
     httpHeader += "\r\nMetadata-Flavor: Google\r\n\r\n";
@@ -98,7 +97,7 @@ unique_ptr<utils::DataVector<uint8_t>> GCP::getRequest(const string& filePath, c
     httpHeader += " " + request.path + " ";
     httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
-    for (auto& h : request.headers)
+    for (const auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
     httpHeader += "\r\n";
 
@@ -133,7 +132,7 @@ unique_ptr<utils::DataVector<uint8_t>> GCP::putRequestGeneric(const string& file
     httpHeader += " " + request.path + " ";
     httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
-    for (auto& h : request.headers)
+    for (const auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
     httpHeader += "\r\n";
 
@@ -164,7 +163,7 @@ unique_ptr<utils::DataVector<uint8_t>> GCP::deleteRequestGeneric(const string& f
     httpHeader += " " + request.path + " ";
     httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
-    for (auto& h : request.headers)
+    for (const auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
     httpHeader += "\r\n";
 
@@ -192,7 +191,7 @@ unique_ptr<utils::DataVector<uint8_t>> GCP::createMultiPartRequest(const string&
     httpHeader += " " + request.path + " ";
     httpHeader += network::HttpRequest::getRequestType(request.type);
     httpHeader += "\r\n";
-    for (auto& h : request.headers)
+    for (const auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
     httpHeader += "\r\n";
 
@@ -232,7 +231,7 @@ unique_ptr<utils::DataVector<uint8_t>> GCP::completeMultiPartRequest(const strin
     httpHeaderMessage += network::HttpRequest::getRequestType(request.type);
     httpHeaderMessage += "\r\n";
 
-    for (auto& h : request.headers)
+    for (const auto& h : request.headers)
         httpHeaderMessage += h.first + ": " + h.second + "\r\n";
     httpHeaderMessage += "\r\n" + content;
     return make_unique<utils::DataVector<uint8_t>>(reinterpret_cast<uint8_t*>(httpHeaderMessage.data()), reinterpret_cast<uint8_t*>(httpHeaderMessage.data() + httpHeaderMessage.size()));

--- a/src/cloud/gcp.cpp
+++ b/src/cloud/gcp.cpp
@@ -46,8 +46,8 @@ Provider::Instance GCP::getInstanceDetails(network::TaskedSendReceiver& sendRece
 {
     auto message = downloadInstanceInfo();
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), getIAMAddress(), getIAMPort());
-    sendReceiver.send(originalMsg.get());
-    sendReceiver.process();
+    sendReceiver.sendSync(originalMsg.get());
+    sendReceiver.processSync();
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HTTPHelper::Info> infoPtr;
     auto s = network::HTTPHelper::retrieveContent(content.cdata(), content.size(), infoPtr);
@@ -65,8 +65,8 @@ string GCP::getInstanceRegion(network::TaskedSendReceiver& sendReceiver)
 {
     auto message = downloadInstanceInfo("zone");
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), getIAMAddress(), getIAMPort());
-    sendReceiver.send(originalMsg.get());
-    sendReceiver.process();
+    sendReceiver.sendSync(originalMsg.get());
+    sendReceiver.processSync();
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HTTPHelper::Info> infoPtr;
     auto s = network::HTTPHelper::retrieveContent(content.cdata(), content.size(), infoPtr);

--- a/src/cloud/gcp_signer.cpp
+++ b/src/cloud/gcp_signer.cpp
@@ -42,7 +42,7 @@ string GCPSigner::createSignedRequest(const string& serviceAccountEmail, const s
             sorted.emplace(key, it->second);
             ++it;
         }
-        for (auto& h : sorted)
+        for (const auto& h : sorted)
             headers << h.first << ":" << h.second << "\n";
     }
 

--- a/src/cloud/gcp_signer.cpp
+++ b/src/cloud/gcp_signer.cpp
@@ -23,7 +23,7 @@ string GCPSigner::createSignedRequest(const string& serviceAccountEmail, const s
 {
     stringstream requestStream;
     // canonicalize request method
-    requestStream << network::HttpRequest::getRequestMethod(request) << "\n";
+    requestStream << network::HttpRequest::getRequestMethod(request.method) << "\n";
 
     // canonicalize request path; assume that path is RFC 3986 conform
     if (request.path.empty())

--- a/src/cloud/provider.cpp
+++ b/src/cloud/provider.cpp
@@ -5,8 +5,8 @@
 #include "cloud/ibm.hpp"
 #include "cloud/minio.hpp"
 #include "cloud/oracle.hpp"
-#include "network/tasked_send_receiver.hpp"
 #include "network/config.hpp"
+#include "network/tasked_send_receiver.hpp"
 #include "utils/data_vector.hpp"
 #include <fstream>
 #include <istream>
@@ -82,6 +82,12 @@ Provider::RemoteInfo Provider::getRemoteInfo(const string& fileName) {
             } else {
                 info.bucket = bucketRegion;
                 info.region = "";
+            }
+            if (!remoteFile[i].compare("s3://")) {
+                // Handle s3 one zone express
+                if (info.bucket.size() > 6 && info.bucket.find("--x-s3", info.bucket.size() - 7)) {
+                    info.zonal = true;
+                }
             }
             info.provider = static_cast<CloudService>(i);
         }

--- a/src/cloud/provider.cpp
+++ b/src/cloud/provider.cpp
@@ -175,7 +175,7 @@ unique_ptr<utils::DataVector<uint8_t>> Provider::createMultiPartRequest(const st
     return nullptr;
 }
 //---------------------------------------------------------------------------
-unique_ptr<utils::DataVector<uint8_t>> Provider::completeMultiPartRequest(const string& /*filePath*/, string_view /*uploadId*/, const vector<string>& /*etags*/) const
+unique_ptr<utils::DataVector<uint8_t>> Provider::completeMultiPartRequest(const string& /*filePath*/, string_view /*uploadId*/, const vector<string>& /*etags*/, string& /*content*/) const
 // Builds the http request for completing multipart put objects
 {
     return nullptr;

--- a/src/network/http_helper.cpp
+++ b/src/network/http_helper.cpp
@@ -17,7 +17,7 @@ namespace network {
 //---------------------------------------------------------------------------
 using namespace std;
 //---------------------------------------------------------------------------
-HTTPHelper::Info HTTPHelper::detect(string_view header)
+HttpHelper::Info HttpHelper::detect(string_view header)
 // Detect the protocol
 {
     static constexpr auto unknown = Info{0, 0, Protocol::Unknown, Encoding::Unknown};
@@ -68,7 +68,7 @@ HTTPHelper::Info HTTPHelper::detect(string_view header)
     return info;
 }
 //---------------------------------------------------------------------------
-string_view HTTPHelper::retrieveContent(const uint8_t* data, uint64_t length, unique_ptr<Info>& info)
+string_view HttpHelper::retrieveContent(const uint8_t* data, uint64_t length, unique_ptr<Info>& info)
 // Retrieve the content without http meta info, note that this changes data
 {
     string_view sv(reinterpret_cast<const char*>(data), length);
@@ -79,7 +79,7 @@ string_view HTTPHelper::retrieveContent(const uint8_t* data, uint64_t length, un
     return {};
 }
 //---------------------------------------------------------------------------
-bool HTTPHelper::finished(const uint8_t* data, uint64_t length, unique_ptr<Info>& info)
+bool HttpHelper::finished(const uint8_t* data, uint64_t length, unique_ptr<Info>& info)
 // Detect end / content
 {
     if (!info) {

--- a/src/network/http_helper.cpp
+++ b/src/network/http_helper.cpp
@@ -29,6 +29,7 @@ HttpHelper::Info HttpHelper::detect(string_view header)
     static constexpr string_view contentLength = "Content-Length";
     static constexpr string_view headerEnd = "\r\n\r\n";
 
+    info.encoding = Encoding::Unknown;
     for (auto& keyValue : info.response.headers) {
         if (transferEncoding == keyValue.first && chunkedEncoding == keyValue.second) {
             info.encoding = Encoding::ChunkedEncoding;
@@ -44,7 +45,7 @@ HttpHelper::Info HttpHelper::detect(string_view header)
         }
     }
 
-    if (!info.headerLength)
+    if (info.encoding == Encoding::Unknown)
         throw runtime_error("Unsupported HTTP encoding protocol");
 
     return info;

--- a/src/network/http_message.cpp
+++ b/src/network/http_message.cpp
@@ -97,9 +97,8 @@ MessageState HTTPMessage::execute(IOUringSocket& socket)
                         // check whether finished http
                         if (HttpHelper::finished(receive.data(), static_cast<uint64_t>(receiveBufferOffset), info)) {
                             socket.disconnect(request->fd, originalMessage->hostname, originalMessage->port, &tcpSettings, static_cast<uint64_t>(sendBufferOffset + receiveBufferOffset));
-                            originalMessage->result.size = info->length;
-                            originalMessage->result.offset = info->headerLength;
-                            if (HttpResponse::checkSuccess(info->response.code)) {
+                            originalMessage->result.response = move(info);
+                            if (HttpResponse::checkSuccess(originalMessage->result.response->response.code)) {
                                 state = MessageState::Finished;
                             } else {
                                 originalMessage->result.failureCode |= static_cast<uint16_t>(MessageFailureCode::HTTP);

--- a/src/network/http_message.cpp
+++ b/src/network/http_message.cpp
@@ -94,7 +94,7 @@ MessageState HTTPMessage::execute(IOUringSocket& socket)
 
                     try {
                         // check whether finished http
-                        if (HTTPHelper::finished(receive.data(), static_cast<uint64_t>(receiveBufferOffset), info)) {
+                        if (HttpHelper::finished(receive.data(), static_cast<uint64_t>(receiveBufferOffset), info)) {
                             socket.disconnect(request->fd, originalMessage->hostname, originalMessage->port, &tcpSettings, static_cast<uint64_t>(sendBufferOffset + receiveBufferOffset));
                             originalMessage->result.size = info->length;
                             originalMessage->result.offset = info->headerLength;

--- a/src/network/http_request.cpp
+++ b/src/network/http_request.cpp
@@ -1,6 +1,10 @@
 #include "network/http_request.hpp"
 #include "utils/data_vector.hpp"
 #include "utils/utils.hpp"
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
 //---------------------------------------------------------------------------
 // AnyBlob - Universal Cloud Object Storage Library
 // Dominik Durner, 2024
@@ -14,10 +18,121 @@ namespace network {
 //---------------------------------------------------------------------------
 using namespace std;
 //---------------------------------------------------------------------------
-HttpRequest HttpRequest::deserialize(string_view /*data*/)
+HttpRequest HttpRequest::deserialize(string_view data)
 // Deserialize the http header
 {
+    static constexpr string_view strHttp1_0 = "HTTP/1.0";
+    static constexpr string_view strHttp1_1 = "HTTP/1.1";
+    static constexpr string_view strGet = "GET";
+    static constexpr string_view strPost = "POST";
+    static constexpr string_view strPut = "PUT";
+    static constexpr string_view strDelete = "DELETE";
+    static constexpr string_view strNewline = "\r\n";
+    static constexpr string_view strHeaderSeperator = ": ";
+    static constexpr string_view strQuerySeperator = "=";
+    static constexpr string_view strQueryStart = "?";
+    static constexpr string_view strQueryAnd = "&";
+
     HttpRequest request;
+
+    string_view line;
+    auto firstLine = true;
+    while (true) {
+        auto pos = data.find(strNewline);
+        if (pos == data.npos)
+            break;
+        line = data.substr(0, pos);
+        data = data.substr(pos + strNewline.size());
+        if (line.empty()) {
+            if (!firstLine)
+                break;
+            else
+                throw runtime_error("Invalid HttpRequest: Missing first line!");
+        }
+        if (firstLine) {
+            // parse method
+            if (line.starts_with(strGet)) {
+                firstLine = false;
+                request.method = HttpRequest::Method::GET;
+                line = line.substr(strGet.size());
+            } else if (line.starts_with(strPost)) {
+                firstLine = false;
+                request.method = HttpRequest::Method::POST;
+                line = line.substr(strPost.size());
+            } else if (line.starts_with(strPut)) {
+                firstLine = false;
+                request.method = HttpRequest::Method::PUT;
+                line = line.substr(strPut.size());
+            } else if (line.starts_with(strDelete)) {
+                firstLine = false;
+                request.method = HttpRequest::Method::DELETE;
+                line = line.substr(strDelete.size());
+            } else {
+                throw runtime_error("Invalid HttpRequest: Needs to start with request method!");
+            }
+
+            // parse path, requires HTTP type, otherwise invalid
+            pos = line.find(" ", 1);
+            if (pos == line.npos)
+                throw runtime_error("Invalid HttpRequest: Could not find path, or missing HTTP type!");
+            auto pathQuery = line.substr(1, pos - 1);
+            // the http type
+            line = line.substr(pos + 1);
+
+            // split path and query
+            auto queriesPos = pathQuery.find(strQueryStart);
+            if (queriesPos != pathQuery.npos) {
+                // with query
+                request.path = pathQuery.substr(0, queriesPos);
+                auto queries = pathQuery.substr(queriesPos + 1);
+                while (true) {
+                    auto queryPos = queries.find(strQueryAnd);
+                    string_view query;
+                    if (queryPos == queries.npos)
+                        query = queries;
+                    else
+                        query = queries.substr(0, queryPos); // skip the ? or the &
+
+                    // split between key and value (value might be unnecassary)
+                    auto keyPos = query.find(strQuerySeperator);
+                    string_view key, value = "";
+                    if (keyPos == query.npos) {
+                        key = query;
+                    } else {
+                        key = query.substr(0, keyPos);
+                        value = query.substr(keyPos + 1);
+                    }
+                    request.queries.emplace(key, value);
+                    if (queryPos == queries.npos)
+                        break;
+                    queries = queries.substr(queryPos + 1);
+                }
+            } else {
+                request.path = pathQuery;
+            }
+
+            // the http type
+            if (line.starts_with(strHttp1_0)) {
+                request.type = HttpRequest::Type::HTTP_1_0;
+            } else if (line.starts_with(strHttp1_1)) {
+                request.type = HttpRequest::Type::HTTP_1_1;
+            } else {
+                throw runtime_error("Invalid HttpRequest: Needs to be a HTTP type 1.0 or 1.1!");
+            }
+        } else {
+            // headers
+            auto keyPos = line.find(strHeaderSeperator);
+            string_view key, value = "";
+            if (keyPos == line.npos) {
+                throw runtime_error("Invalid HttpRequest: Headers need key and value!");
+            } else {
+                key = line.substr(0, keyPos);
+                value = line.substr(keyPos + strHeaderSeperator.size());
+            }
+            request.headers.emplace(key, value);
+        }
+    }
+
     return request;
 }
 //---------------------------------------------------------------------------
@@ -25,7 +140,9 @@ unique_ptr<utils::DataVector<uint8_t>> HttpRequest::serialize(const HttpRequest&
 // Serialize an http header
 {
     string httpHeader = getRequestMethod(request);
-    httpHeader += " ";
+    httpHeader += " " + request.path;
+    if (request.queries.size())
+         httpHeader += "?";
     auto it = request.queries.begin();
     while (it != request.queries.end()) {
         httpHeader += utils::encodeUrlParameters(it->first) + "=" + utils::encodeUrlParameters(it->second);

--- a/src/network/http_request.cpp
+++ b/src/network/http_request.cpp
@@ -1,0 +1,45 @@
+#include "network/http_request.hpp"
+#include "utils/data_vector.hpp"
+#include "utils/utils.hpp"
+//---------------------------------------------------------------------------
+// AnyBlob - Universal Cloud Object Storage Library
+// Dominik Durner, 2024
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+//---------------------------------------------------------------------------
+namespace anyblob {
+namespace network {
+//---------------------------------------------------------------------------
+using namespace std;
+//---------------------------------------------------------------------------
+HttpRequest HttpRequest::deserialize(string_view /*data*/)
+// Deserialize the http header
+{
+    HttpRequest request;
+    return request;
+}
+//---------------------------------------------------------------------------
+unique_ptr<utils::DataVector<uint8_t>> HttpRequest::serialize(const HttpRequest& request)
+// Serialize an http header
+{
+    string httpHeader = getRequestMethod(request);
+    httpHeader += " ";
+    auto it = request.queries.begin();
+    while (it != request.queries.end()) {
+        httpHeader += utils::encodeUrlParameters(it->first) + "=" + utils::encodeUrlParameters(it->second);
+        if (++it != request.queries.end())
+            httpHeader += "&";
+    }
+    httpHeader += " ";
+    httpHeader += getRequestType(request);
+    httpHeader += "\r\n";
+    for (auto& h : request.headers)
+        httpHeader += h.first + ": " + h.second + "\r\n";
+    httpHeader += "\r\n";
+    return make_unique<utils::DataVector<uint8_t>>(reinterpret_cast<uint8_t*>(httpHeader.data()), reinterpret_cast<uint8_t*>(httpHeader.data() + httpHeader.size()));
+}
+//---------------------------------------------------------------------------
+} // namespace network
+} // namespace anyblob

--- a/src/network/http_request.cpp
+++ b/src/network/http_request.cpp
@@ -150,7 +150,7 @@ unique_ptr<utils::DataVector<uint8_t>> HttpRequest::serialize(const HttpRequest&
     httpHeader += " ";
     httpHeader += getRequestType(request.type);
     httpHeader += "\r\n";
-    for (auto& h : request.headers)
+    for (const auto& h : request.headers)
         httpHeader += h.first + ": " + h.second + "\r\n";
     httpHeader += "\r\n";
     return make_unique<utils::DataVector<uint8_t>>(reinterpret_cast<uint8_t*>(httpHeader.data()), reinterpret_cast<uint8_t*>(httpHeader.data() + httpHeader.size()));

--- a/src/network/http_response.cpp
+++ b/src/network/http_response.cpp
@@ -1,0 +1,86 @@
+#include "network/http_response.hpp"
+#include "utils/data_vector.hpp"
+#include "utils/utils.hpp"
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+//---------------------------------------------------------------------------
+// AnyBlob - Universal Cloud Object Storage Library
+// Dominik Durner, 2024
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+//---------------------------------------------------------------------------
+namespace anyblob {
+namespace network {
+//---------------------------------------------------------------------------
+using namespace std;
+//---------------------------------------------------------------------------
+HttpResponse HttpResponse::deserialize(string_view data)
+// Deserialize the http header
+{
+    static constexpr string_view strHttp1_0 = "HTTP/1.0";
+    static constexpr string_view strHttp1_1 = "HTTP/1.1";
+    static constexpr string_view strNewline = "\r\n";
+    static constexpr string_view strHeaderSeperator = ": ";
+
+    HttpResponse response;
+
+    string_view line;
+    auto firstLine = true;
+    while (true) {
+        auto pos = data.find(strNewline);
+        if (pos == data.npos)
+            throw runtime_error("Invalid HttpResponse: Incomplete header!");
+
+        line = data.substr(0, pos);
+        data = data.substr(pos + strNewline.size());
+        if (line.empty()) {
+            if (!firstLine)
+                break;
+            else
+                throw runtime_error("Invalid HttpResponse: Missing first line!");
+        }
+        if (firstLine) {
+            firstLine = false;
+            // the http type
+            if (line.starts_with(strHttp1_0)) {
+                response.type = Type::HTTP_1_0;
+            } else if (line.starts_with(strHttp1_1)) {
+                response.type = Type::HTTP_1_1;
+            } else {
+                throw runtime_error("Invalid HttpResponse: Needs to be a HTTP type 1.0 or 1.1!");
+            }
+
+            string_view httpType = getResponseType(response.type);
+            line = line.substr(httpType.size() + 1);
+
+            // the response type
+            response.code = Code::UNKNOWN;
+            for (auto code = static_cast<uint8_t>(Code::OK_200); code <= static_cast<uint8_t>(Code::SLOW_DOWN_503); code++) {
+                const string_view responseCode = getResponseCode(static_cast<Code>(code));
+                if (line.starts_with(responseCode)) {
+                    response.code = static_cast<Code>(code);
+                }
+            }
+        } else {
+            // headers
+            auto keyPos = line.find(strHeaderSeperator);
+            string_view key, value = "";
+            if (keyPos == line.npos) {
+                throw runtime_error("Invalid HttpResponse: Headers need key and value!");
+            } else {
+                key = line.substr(0, keyPos);
+                value = line.substr(keyPos + strHeaderSeperator.size());
+            }
+            response.headers.emplace(key, value);
+        }
+    }
+
+    return response;
+}
+//---------------------------------------------------------------------------
+} // namespace network
+} // namespace anyblob

--- a/src/network/https_message.cpp
+++ b/src/network/https_message.cpp
@@ -103,9 +103,8 @@ MessageState HTTPSMessage::execute(IOUringSocket& socket)
                 receiveBufferOffset += result;
                 try {
                     if (HttpHelper::finished(receive.data(), static_cast<uint64_t>(receiveBufferOffset), info)) {
-                        originalMessage->result.size = info->length;
-                        originalMessage->result.offset = info->headerLength;
-                        if (HttpResponse::checkSuccess(info->response.code)) {
+                        originalMessage->result.response = move(info);
+                        if (HttpResponse::checkSuccess(originalMessage->result.response->response.code)) {
                             state = MessageState::TLSShutdown;
                         } else {
                             originalMessage->result.failureCode |= static_cast<uint16_t>(MessageFailureCode::HTTP);

--- a/src/network/https_message.cpp
+++ b/src/network/https_message.cpp
@@ -101,7 +101,7 @@ MessageState HTTPSMessage::execute(IOUringSocket& socket)
                 receive.resize(receive.size() - (chunkSize - static_cast<uint64_t>(result)));
                 receiveBufferOffset += result;
                 try {
-                    if (HTTPHelper::finished(receive.data(), static_cast<uint64_t>(receiveBufferOffset), info)) {
+                    if (HttpHelper::finished(receive.data(), static_cast<uint64_t>(receiveBufferOffset), info)) {
                         originalMessage->result.size = info->length;
                         originalMessage->result.offset = info->headerLength;
                         state = MessageState::TLSShutdown;

--- a/src/network/io_uring_socket.cpp
+++ b/src/network/io_uring_socket.cpp
@@ -57,7 +57,7 @@ IOUringSocket::IOUringSocket(uint32_t entries, int32_t /*flags*/) : _resolverCac
 #endif
 }
 //---------------------------------------------------------------------------
-int32_t IOUringSocket::connect(string hostname, uint32_t port, TCPSettings& tcpSettings, int retryLimit)
+int32_t IOUringSocket::connect(string hostname, uint32_t port, const TCPSettings& tcpSettings, int retryLimit)
 // Creates a new socket connection
 {
     if (auto it = _fdCache.find(hostname); it != _fdCache.end()) {
@@ -188,7 +188,7 @@ int32_t IOUringSocket::connect(string hostname, uint32_t port, TCPSettings& tcpS
     }
 #endif
 
-    auto setTimeOut = [](int fd, TCPSettings& tcpSettings) {
+    auto setTimeOut = [](int fd, const TCPSettings& tcpSettings) {
         // Set timeout
         if (tcpSettings.timeout > 0) {
             struct timeval tv;
@@ -262,7 +262,7 @@ int32_t IOUringSocket::connect(string hostname, uint32_t port, TCPSettings& tcpS
     return fd;
 }
 //---------------------------------------------------------------------------
-void IOUringSocket::disconnect(int32_t fd, string hostname, uint32_t port, TCPSettings* tcpSettings, uint64_t bytes, bool forceShutdown)
+void IOUringSocket::disconnect(int32_t fd, string hostname, uint32_t port, const TCPSettings* tcpSettings, uint64_t bytes, bool forceShutdown)
 // Disconnects the socket
 {
     Resolver* resCache;
@@ -432,7 +432,7 @@ void IOUringSocket::wait()
         throw runtime_error("Wait error!");
 }
 //---------------------------------------------------------------------------
-bool IOUringSocket::checkTimeout(int fd, TCPSettings& tcpSettings)
+bool IOUringSocket::checkTimeout(int fd, const TCPSettings& tcpSettings)
 // Check for a timeout
 {
     pollfd p = {fd, POLLIN, 0};

--- a/src/network/resolver.cpp
+++ b/src/network/resolver.cpp
@@ -24,7 +24,7 @@ string_view Resolver::tld(string_view domain)
     if (pos != string::npos) {
         pos = domain.substr(0, pos - 1).find_last_of('.');
         if (pos == string::npos)
-            return string_view(domain);
+            return domain;
         else
             return string_view(domain).substr(pos + 1, domain.size());
     }

--- a/src/network/tasked_send_receiver.cpp
+++ b/src/network/tasked_send_receiver.cpp
@@ -149,12 +149,12 @@ void TaskedSendReceiver::run()
 {
     try {
         sendReceive(false, false);
-    } catch (exception& e) {
+    } catch (const exception& e) {
         cerr << e.what() << endl;
     };
 }
 //---------------------------------------------------------------------------
-int32_t TaskedSendReceiver::connect(string hostname, uint32_t port)
+int32_t TaskedSendReceiver::connect(const string& hostname, uint32_t port)
 // Connect to the socket
 {
     IOUringSocket::TCPSettings tcpSettings;
@@ -275,7 +275,7 @@ void TaskedSendReceiver::sendReceive(bool local, bool oneQueueInvocation)
             IOUringSocket::Request* req;
             try {
                 req = _socketWrapper->complete();
-            } catch (exception& e) {
+            } catch (const exception& e) {
                 continue;
             }
             // reduce count

--- a/src/network/throughput_resolver.cpp
+++ b/src/network/throughput_resolver.cpp
@@ -98,8 +98,6 @@ void ThroughputResolver::stopSocket(int fd, uint64_t bytes)
             auto percentile = _throughputTree.find_by_order(maxElem / 6);
             if (percentile.m_p_nd->m_value <= throughput)
                 _addrString[it->second.first].second += 2;
-            else
-                possible = false;
         }
     }
 }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -45,6 +45,9 @@ pair<unique_ptr<uint8_t[]>, uint64_t> base64Decode(const uint8_t* input, uint64_
     assert(in_range<int>(length));
     auto baseLength = 3 * length / 4;
     auto buffer = make_unique<uint8_t[]>(baseLength + 1);
+    if (!length) {
+        return {move(buffer), 0};
+    }
     auto decodeLength = EVP_DecodeBlock(reinterpret_cast<unsigned char*>(buffer.get()), input, static_cast<int>(length));
     if (decodeLength < 0 || static_cast<unsigned>(decodeLength) != baseLength)
         throw runtime_error("OpenSSL Error!");

--- a/test/unit/cloud/aws_test.cpp
+++ b/test/unit/cloud/aws_test.cpp
@@ -39,14 +39,15 @@ class AWSTester {
         resultString = "GET /latest/meta-data/iam/security-credentials HTTP/1.1\r\nHost: 169.254.169.254\r\n\r\n";
         REQUIRE(string_view(reinterpret_cast<char*>(dv->data()), dv->size()) == resultString);
 
-        dv = aws.downloadSecret("ABCDEF\n");
+        string iamUser;
+        dv = aws.downloadSecret("ABCDEF\n", iamUser);
         resultString = "GET /latest/meta-data/iam/security-credentials/ABCDEF HTTP/1.1\r\nHost: 169.254.169.254\r\n\r\n";
         REQUIRE(string_view(reinterpret_cast<char*>(dv->data()), dv->size()) == resultString);
 
         string keyService = "{\"AccessKeyId\" : \"ABC\", \"SecretAccessKey\" : \"ABC\", \"Token\" : \"ABC\", \"Expiration\" : \"";
         keyService += aws.fakeIAMTimestamp;
         keyService += "\"}";
-        REQUIRE(aws.updateSecret(keyService));
+        REQUIRE(aws.updateSecret(keyService, iamUser));
 
         auto p = pair<uint64_t, uint64_t>(numeric_limits<uint64_t>::max(), numeric_limits<uint64_t>::max());
         dv = aws.getRequest("a/b/c.d", p);

--- a/test/unit/network/http_request_test.cpp
+++ b/test/unit/network/http_request_test.cpp
@@ -1,0 +1,41 @@
+#include "network/http_request.hpp"
+#include "utils/data_vector.hpp"
+#include "catch2/single_include/catch2/catch.hpp"
+#include <iostream>
+//---------------------------------------------------------------------------
+// AnyBlob - Universal Cloud Object Storage Library
+// Dominik Durner, 2022
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+//---------------------------------------------------------------------------
+namespace anyblob {
+namespace network {
+namespace test {
+//---------------------------------------------------------------------------
+TEST_CASE("http_request") {
+    network::HttpRequest request;
+
+    request.method = network::HttpRequest::Method::GET;
+    request.path = "/test";
+    request.type = network::HttpRequest::Type::HTTP_1_1;
+    request.queries.emplace("key", "value");
+    request.queries.emplace("key2", "value2");
+    request.headers.emplace("Authorization", "test");
+    request.headers.emplace("Timestamp", "2024-02-18 00:00:00");
+
+    auto serialize = network::HttpRequest::serialize(request);
+    auto serializeView = std::string_view(reinterpret_cast<char*>(serialize->data()), serialize->size());
+
+    auto deserializedRequest = network::HttpRequest::deserialize(serializeView);
+
+    auto serializeAgain = network::HttpRequest::serialize(deserializedRequest);
+    auto serializeAgainView = std::string_view(reinterpret_cast<char*>(serializeAgain->data()), serializeAgain->size());
+
+    REQUIRE(serializeView == serializeAgainView);
+}
+//---------------------------------------------------------------------------
+} // namespace test
+} // namespace network
+} // namespace anyblob


### PR DESCRIPTION
This commit allows to serialize and deserialize request headers which can be used to:

1.  Resign request with new keys after keys lifetime ends
2.  Restart queries at arbitrary position by sending new requests with only the needed parts (e.g. change the range).

Further, http response is now kept for better debugging of (negative) object storage response.