### PR TITLE
AnyBlob Redesign for TLS connection reusage, better caching of fds, and resinging of requests

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -6,6 +6,6 @@ runs:
     steps:
       # Install dependencies
       - name: Install dependencies
-        run: sudo apt update && sudo apt install liburing-dev openssl libssl-dev libjemalloc-dev lld
+        run: sudo apt update && sudo apt install liburing-dev openssl libssl-dev libjemalloc-dev lld && sudo sysctl -w vm.mmap_rnd_bits=28
         shell: bash
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
 
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address,undefined -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -Wmissing-declarations -Wno-unqualified-std-cast-call -Wvla -Wconversion -Werror")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -Wmissing-declarations -Wno-unqualified-std-cast-call -Wvla -Wconversion -Werror")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -Wmissing-declarations -Wno-unqualified-std-cast-call -Wvla -Wconversion -Werror")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -Wmissing-declarations -Wno-unqualified-std-cast-call -Wvla -Wconversion -Werror")
 set(CMAKE_CXX_FLAGS_COVERAGE "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Wold-style-cast -Woverloaded-virtual -Wmissing-declarations -Wno-unqualified-std-cast-call -Wvla -Wconversion -Werror -coverage")

--- a/example/benchmark/src/benchmark/bandwidth.cpp
+++ b/example/benchmark/src/benchmark/bandwidth.cpp
@@ -1,6 +1,6 @@
 #include "benchmark/bandwidth.hpp"
 #include "cloud/aws.hpp"
-#include "cloud/aws_resolver.hpp"
+#include "cloud/aws_cache.hpp"
 #include "cloud/azure.hpp"
 #include "cloud/gcp.hpp"
 #include "network/original_message.hpp"
@@ -172,7 +172,7 @@ void Bandwidth::runUring(const Settings& benchmarkSettings, const string& uri)
         auto awsProvider = static_cast<cloud::AWS*>(cloudProvider.get());
         if (!benchmarkSettings.resolver.compare("aws")) {
             for (auto i = 0u; i < benchmarkSettings.concurrentThreads; i++) {
-                awsProvider->initResolver(*sendReceiverHandles[i].get());
+                awsProvider->initCache(*sendReceiverHandles[i].get());
             }
         }
     }

--- a/example/simple/main.cpp
+++ b/example/simple/main.cpp
@@ -28,8 +28,8 @@ int main(int /*argc*/, char** /*argv*/) {
     bool https = false;
     auto provider = anyblob::cloud::Provider::makeProvider(bucketName, https, "", "", &sendReceiverHandle);
 
-    // Optionally init the specialized aws resolver
-    // provider->initResolver(sendReceiverHandle);
+    // Optionally init the specialized aws cache
+    // provider->initCache(sendReceiverHandle);
 
     // Update the concurrency according to instance settings
     auto config = provider->getConfig(sendReceiverHandle);

--- a/example/simple/main.cpp
+++ b/example/simple/main.cpp
@@ -22,17 +22,17 @@ int main(int /*argc*/, char** /*argv*/) {
     anyblob::network::TaskedSendReceiverGroup group;
 
     // Create an AnyBlob scheduler object for the group
-    anyblob::network::TaskedSendReceiver sendReceiver(group);
+    auto sendReceiverHandle = group.getHandle();
 
     // Create the provider for the corresponding filename
     bool https = false;
-    auto provider = anyblob::cloud::Provider::makeProvider(bucketName, https, "", "", &sendReceiver);
+    auto provider = anyblob::cloud::Provider::makeProvider(bucketName, https, "", "", &sendReceiverHandle);
 
     // Optionally init the specialized aws resolver
-    // provider->initResolver(sendReceiver);
+    // provider->initResolver(sendReceiverHandle);
 
     // Update the concurrency according to instance settings
-    auto config = provider->getConfig(sendReceiver);
+    auto config = provider->getConfig(sendReceiverHandle);
     group.setConfig(config);
 
     // Create the get request
@@ -45,7 +45,7 @@ int main(int /*argc*/, char** /*argv*/) {
         getTxn.getObjectRequest(fileName);
 
     // Retrieve the request synchronously with the scheduler object on this thread
-    getTxn.processSync(sendReceiver);
+    getTxn.processSync(sendReceiverHandle);
 
     // Get and print the result
     for (const auto& it : getTxn) {

--- a/example/simple/main.cpp
+++ b/example/simple/main.cpp
@@ -25,7 +25,11 @@ int main(int /*argc*/, char** /*argv*/) {
     anyblob::network::TaskedSendReceiver sendReceiver(group);
 
     // Create the provider for the corresponding filename
-    auto provider = anyblob::cloud::Provider::makeProvider(bucketName, false, "", "", &sendReceiver);
+    bool https = false;
+    auto provider = anyblob::cloud::Provider::makeProvider(bucketName, https, "", "", &sendReceiver);
+
+    // Optionally init the specialized aws resolver
+    // provider->initResolver(sendReceiver);
 
     // Update the concurrency according to instance settings
     auto config = provider->getConfig(sendReceiver);
@@ -34,6 +38,11 @@ int main(int /*argc*/, char** /*argv*/) {
     // Create the get request
     anyblob::network::Transaction getTxn(provider.get());
     getTxn.getObjectRequest(fileName);
+
+    // Create optionally more requests within a transaction
+    auto requests = 64u;
+    for (auto i = 0u; i < requests; i++)
+        getTxn.getObjectRequest(fileName);
 
     // Retrieve the request synchronously with the scheduler object on this thread
     getTxn.processSync(sendReceiver);

--- a/include/cloud/aws.hpp
+++ b/include/cloud/aws.hpp
@@ -131,6 +131,8 @@ class AWS : public Provider {
 
     /// Creates the generic http request and signs it
     [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> buildRequest(network::HttpRequest& request, const uint8_t* bodyData = nullptr, uint64_t bodyLength = 0, bool initHeaders = true) const;
+    /// Reigns header
+    [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> resignRequest(const utils::DataVector<uint8_t>& data, const uint8_t* bodyData = nullptr, uint64_t bodyLength = 0) const override;
     /// Builds the http request for downloading a blob or listing the directory
     [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> getRequest(const std::string& filePath, const std::pair<uint64_t, uint64_t>& range) const override;
     /// Builds the http request for putting objects without the object data itself

--- a/include/cloud/aws.hpp
+++ b/include/cloud/aws.hpp
@@ -81,11 +81,11 @@ class AWS : public Provider {
 
     public:
     /// Get instance details
-    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiver& sendReceiver) override;
+    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiverHandle& sendReceiver) override;
     /// Get the region of the instance
-    [[nodiscard]] static std::string getInstanceRegion(network::TaskedSendReceiver& sendReceiver);
+    [[nodiscard]] static std::string getInstanceRegion(network::TaskedSendReceiverHandle& sendReceiver);
     /// Init the resolver
-    void initResolver(network::TaskedSendReceiver& sendReceiver) override;
+    void initResolver(network::TaskedSendReceiverHandle& sendReceiverHandle) override;
 
     /// The constructor
     explicit AWS(const RemoteInfo& info) : _settings({info.bucket, info.region, info.endpoint, info.port, info.zonal}), _mutex() {
@@ -109,7 +109,7 @@ class AWS : public Provider {
 
     private:
     /// Initialize secret
-    void initSecret(network::TaskedSendReceiver& sendReceiver) override;
+    void initSecret(network::TaskedSendReceiverHandle& sendReceiverHandle) override;
     /// Get a local copy of the global secret
     void getSecret() override;
     /// Builds the secret http request

--- a/include/cloud/aws.hpp
+++ b/include/cloud/aws.hpp
@@ -84,8 +84,8 @@ class AWS : public Provider {
     [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiverHandle& sendReceiver) override;
     /// Get the region of the instance
     [[nodiscard]] static std::string getInstanceRegion(network::TaskedSendReceiverHandle& sendReceiver);
-    /// Init the resolver
-    void initResolver(network::TaskedSendReceiverHandle& sendReceiverHandle) override;
+    /// Init the Cache
+    void initCache(network::TaskedSendReceiverHandle& sendReceiverHandle) override;
 
     /// The constructor
     explicit AWS(const RemoteInfo& info) : _settings({info.bucket, info.region, info.endpoint, info.port, info.zonal}), _mutex() {

--- a/include/cloud/aws_cache.hpp
+++ b/include/cloud/aws_cache.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "network/resolver.hpp"
+#include "network/cache.hpp"
 #include <unordered_map>
 //---------------------------------------------------------------------------
 // AnyBlob - Universal Cloud Object Storage Library
@@ -13,18 +13,18 @@ namespace anyblob {
 //---------------------------------------------------------------------------
 namespace cloud {
 //---------------------------------------------------------------------------
-/// Implements the AWS resolver logic
-class AWSResolver : public network::Resolver {
+/// Implements the AWS cache logic
+class AWSCache : public network::Cache {
     /// The good mtu cache
     std::unordered_map<unsigned, bool> _mtuCache;
 
     public:
     /// The constructor
-    explicit AWSResolver(unsigned cacheEntries);
+    explicit AWSCache(unsigned cacheEntries);
     /// The address resolving
     virtual const addrinfo* resolve(std::string hostname, std::string port, bool& reuse) override;
     /// The destructor
-    virtual ~AWSResolver() noexcept = default;
+    virtual ~AWSCache() noexcept = default;
 };
 //---------------------------------------------------------------------------
 }; // namespace cloud

--- a/include/cloud/aws_cache.hpp
+++ b/include/cloud/aws_cache.hpp
@@ -20,11 +20,11 @@ class AWSCache : public network::Cache {
 
     public:
     /// The constructor
-    explicit AWSCache(unsigned cacheEntries);
+    AWSCache();
     /// The address resolving
-    virtual const addrinfo* resolve(std::string hostname, std::string port, bool& reuse) override;
+    virtual std::unique_ptr<network::Cache::SocketEntry> resolve(std::string hostname, unsigned port, bool tls) override;
     /// The destructor
-    virtual ~AWSCache() noexcept = default;
+    virtual ~AWSCache() = default;
 };
 //---------------------------------------------------------------------------
 }; // namespace cloud

--- a/include/cloud/aws_resolver.hpp
+++ b/include/cloud/aws_resolver.hpp
@@ -13,16 +13,16 @@ namespace anyblob {
 //---------------------------------------------------------------------------
 namespace cloud {
 //---------------------------------------------------------------------------
-/// Implements the AWS Resolver logic
+/// Implements the AWS resolver logic
 class AWSResolver : public network::Resolver {
     /// The good mtu cache
     std::unordered_map<unsigned, bool> _mtuCache;
 
     public:
     /// The constructor
-    explicit AWSResolver(unsigned entries);
+    explicit AWSResolver(unsigned cacheEntries);
     /// The address resolving
-    virtual unsigned resolve(std::string hostname, std::string port, bool& reuse) override;
+    virtual const addrinfo* resolve(std::string hostname, std::string port, bool& reuse) override;
     /// The destructor
     virtual ~AWSResolver() noexcept = default;
 };

--- a/include/cloud/azure.hpp
+++ b/include/cloud/azure.hpp
@@ -56,9 +56,9 @@ class Azure : public Provider {
 
     public:
     /// Get instance details
-    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiver& sendReceiver) override;
+    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiverHandle& sendReceiver) override;
     /// Get the region of the instance
-    [[nodiscard]] static std::string getRegion(network::TaskedSendReceiver& sendReceiver);
+    [[nodiscard]] static std::string getRegion(network::TaskedSendReceiverHandle& sendReceiver);
 
     /// The constructor
     Azure(const RemoteInfo& info, const std::string& clientEmail, const std::string& key) : _settings({info.bucket, info.port}) {

--- a/include/cloud/gcp.hpp
+++ b/include/cloud/gcp.hpp
@@ -56,9 +56,9 @@ class GCP : public Provider {
 
     public:
     /// Get instance details
-    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiver& sendReceiver) override;
+    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiverHandle& sendReceiver) override;
     /// Get the region of the instance
-    [[nodiscard]] static std::string getInstanceRegion(network::TaskedSendReceiver& sendReceiver);
+    [[nodiscard]] static std::string getInstanceRegion(network::TaskedSendReceiverHandle& sendReceiver);
 
     /// The constructor
     GCP(const RemoteInfo& info, const std::string& clientEmail, const std::string& key) : _settings({info.bucket, info.region, info.port}) {

--- a/include/cloud/http.hpp
+++ b/include/cloud/http.hpp
@@ -1,0 +1,66 @@
+#pragma once
+#include "cloud/provider.hpp"
+#include <cassert>
+#include <string>
+//---------------------------------------------------------------------------
+// AnyBlob - Universal Cloud Object Storage Library
+// Dominik Durner, 2024
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+//---------------------------------------------------------------------------
+namespace anyblob {
+//---------------------------------------------------------------------------
+namespace network {
+class TaskedSendReceiver;
+}; // namespace network
+//---------------------------------------------------------------------------
+namespace cloud {
+//---------------------------------------------------------------------------
+/// Implements a simple http request logic
+class HTTP : public Provider {
+    public:
+    /// The settings for azure requests
+    struct Settings {
+        /// The container name
+        std::string hostname;
+        /// The port
+        uint32_t port;
+    };
+
+    private:
+    /// The settings
+    Settings _settings;
+
+    public:
+
+    /// The constructor
+    HTTP(const RemoteInfo& info) : _settings({info.endpoint, info.port}) {
+        assert(info.provider == Provider::CloudService::HTTP || info.provider == Provider::CloudService::HTTPS);
+        _type = info.provider;
+    }
+
+    private:
+    /// Get the settings
+    [[nodiscard]] inline Settings getSettings() { return _settings; }
+
+    /// Builds the http request for downloading a blob or listing the directory
+    [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> getRequest(const std::string& filePath, const std::pair<uint64_t, uint64_t>& range) const override;
+    /// Builds the http request for putting objects without the object data itself
+    [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> putRequest(const std::string& filePath, std::string_view object) const override;
+    // Builds the http request for deleting an objects
+    [[nodiscard]] std::unique_ptr<utils::DataVector<uint8_t>> deleteRequest(const std::string& filePath) const override;
+
+    /// Get the address of the server
+    [[nodiscard]] std::string getAddress() const override;
+    /// Get the port of the server
+    [[nodiscard]] uint32_t getPort() const override;
+    /// Get the instance details
+    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiver& sendReceiver) override;
+
+    friend Provider;
+};
+//---------------------------------------------------------------------------
+} // namespace cloud
+} // namespace anyblob

--- a/include/cloud/http.hpp
+++ b/include/cloud/http.hpp
@@ -57,7 +57,7 @@ class HTTP : public Provider {
     /// Get the port of the server
     [[nodiscard]] uint32_t getPort() const override;
     /// Get the instance details
-    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiver& sendReceiver) override;
+    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiverHandle& sendReceiver) override;
 
     friend Provider;
 };

--- a/include/cloud/ibm.hpp
+++ b/include/cloud/ibm.hpp
@@ -33,7 +33,7 @@ class IBM : public AWS {
     /// Get the address of the server
     [[nodiscard]] std::string getAddress() const override;
     /// Get the instance details
-    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiver& sendReceiver) override;
+    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiverHandle& sendReceiver) override;
 
     friend Provider;
 };

--- a/include/cloud/minio.hpp
+++ b/include/cloud/minio.hpp
@@ -28,7 +28,7 @@ class MinIO : public AWS {
     /// Get the address of the server
     [[nodiscard]] std::string getAddress() const override;
     /// Get the instance details
-    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiver& sendReceiver) override;
+    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiverHandle& sendReceiver) override;
     /// Set the upload split size
     constexpr void setMultipartUploadSize(uint64_t size) { _multipartUploadSize = size; }
 

--- a/include/cloud/oracle.hpp
+++ b/include/cloud/oracle.hpp
@@ -28,7 +28,7 @@ class Oracle : public AWS {
     /// Get the address of the server
     [[nodiscard]] std::string getAddress() const override;
     /// Get the instance details
-    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiver& sendReceiver) override;
+    [[nodiscard]] Provider::Instance getInstanceDetails(network::TaskedSendReceiverHandle& sendReceiver) override;
 
     friend Provider;
 };

--- a/include/cloud/provider.hpp
+++ b/include/cloud/provider.hpp
@@ -135,8 +135,8 @@ class Provider {
     /// Create a provider (keyId is access email for GCP/Azure)
     [[nodiscard]] static std::unique_ptr<Provider> makeProvider(const std::string& filepath, bool https = false, const std::string& keyId = "", const std::string& keyFile = "", network::TaskedSendReceiverHandle* sendReceiverHandle = nullptr);
 
-    /// Init the resolver for specific provider
-    virtual void initResolver(network::TaskedSendReceiverHandle& /*sendReceiverHandle*/) {}
+    /// Init the cache for specific provider
+    virtual void initCache(network::TaskedSendReceiverHandle& /*sendReceiverHandle*/) {}
     /// Get the instance infos
     [[nodiscard]] virtual Instance getInstanceDetails(network::TaskedSendReceiverHandle& sendReceiverHandle) = 0;
     /// Get the config

--- a/include/cloud/provider.hpp
+++ b/include/cloud/provider.hpp
@@ -15,6 +15,7 @@ namespace anyblob {
 //---------------------------------------------------------------------------
 namespace network {
 class TaskedSendReceiver;
+class TaskedSendReceiverHandle;
 class Transaction;
 struct Config;
 struct OriginalMessage;
@@ -81,7 +82,7 @@ class Provider {
     /// The type
     CloudService _type;
     /// Initialize secret
-    virtual void initSecret(network::TaskedSendReceiver& /*sendReceiver*/) {}
+    virtual void initSecret(network::TaskedSendReceiverHandle& /*sendReceiverHandle*/) {}
     /// Get a local copy of the global secret
     virtual void getSecret() {}
 
@@ -132,14 +133,14 @@ class Provider {
     [[nodiscard]] static std::vector<std::string> parseCSVRow(std::string_view body);
 
     /// Create a provider (keyId is access email for GCP/Azure)
-    [[nodiscard]] static std::unique_ptr<Provider> makeProvider(const std::string& filepath, bool https = false, const std::string& keyId = "", const std::string& keyFile = "", network::TaskedSendReceiver* sendReceiver = nullptr);
+    [[nodiscard]] static std::unique_ptr<Provider> makeProvider(const std::string& filepath, bool https = false, const std::string& keyId = "", const std::string& keyFile = "", network::TaskedSendReceiverHandle* sendReceiverHandle = nullptr);
 
     /// Init the resolver for specific provider
-    virtual void initResolver(network::TaskedSendReceiver& /*sendReceiver*/) {}
+    virtual void initResolver(network::TaskedSendReceiverHandle& /*sendReceiverHandle*/) {}
     /// Get the instance infos
-    [[nodiscard]] virtual Instance getInstanceDetails(network::TaskedSendReceiver& sendReceiver) = 0;
+    [[nodiscard]] virtual Instance getInstanceDetails(network::TaskedSendReceiverHandle& sendReceiverHandle) = 0;
     /// Get the config
-    [[nodiscard]] virtual network::Config getConfig(network::TaskedSendReceiver& sendReceiver);
+    [[nodiscard]] virtual network::Config getConfig(network::TaskedSendReceiverHandle& sendReceiverHandle);
 
     friend network::Transaction;
 };

--- a/include/cloud/provider.hpp
+++ b/include/cloud/provider.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include <memory>
-#include <vector>
 #include <string>
 #include <string_view>
+#include <vector>
 //---------------------------------------------------------------------------
 // AnyBlob - Universal Cloud Object Storage Library
 // Dominik Durner, 2021
@@ -32,7 +32,7 @@ class Provider {
     /// The remote prefixes count
     static constexpr unsigned remoteFileCount = 8;
     /// The remote prefixes
-    static constexpr std::string_view remoteFile[] = { "http://", "https://", "s3://", "azure://", "gcp://", "oci://", "ibm://", "minio://"};
+    static constexpr std::string_view remoteFile[] = {"http://", "https://", "s3://", "azure://", "gcp://", "oci://", "ibm://", "minio://"};
     /// Are we currently testing the provdiers
     static bool testEnviornment;
 
@@ -109,6 +109,8 @@ class Provider {
     [[nodiscard]] virtual std::unique_ptr<utils::DataVector<uint8_t>> completeMultiPartRequest(const std::string& /*filePath*/, std::string_view /*uploadId*/, const std::vector<std::string>& /*etags*/, std::string& /*eTagsContent*/) const;
     /// Supports resigning?
     [[nodiscard]] virtual bool supportsResigning() const { return false; }
+    /// Reigns header
+    [[nodiscard]] virtual std::unique_ptr<utils::DataVector<uint8_t>> resignRequest(const utils::DataVector<uint8_t>& data, const uint8_t* bodyData = nullptr, uint64_t bodyLength = 0) const;
 
     /// The destructor
     virtual ~Provider() noexcept = default;

--- a/include/network/cache.hpp
+++ b/include/network/cache.hpp
@@ -1,4 +1,7 @@
 #pragma once
+#include "network/tls_connection.hpp"
+#include <deque>
+#include <map>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -21,29 +24,53 @@ class IOUringSocket;
 //---------------------------------------------------------------------------
 /// The addr resolver and cacher, which is not thread safe
 class Cache {
+    public:
+    /// The dns entry
+    struct DnsEntry {
+        /// The addr
+        std::unique_ptr<addrinfo, decltype(&freeaddrinfo)> addr;
+        /// The cache priority
+        int cachePriority = 0;
+
+        /// The constructor
+        DnsEntry(std::unique_ptr<addrinfo, decltype(&freeaddrinfo)> address, int cachePriority = 0) : addr(move(address)), cachePriority(cachePriority) {}
+    };
+
+    /// The fd socket entry
+    struct SocketEntry {
+        /// The DnsEntry
+        std::unique_ptr<DnsEntry> dns;
+        /// The optional tls connection
+        std::unique_ptr<TLSConnection> tls;
+        /// The fd
+        int32_t fd;
+        /// The port
+        unsigned port;
+        /// The hostname
+        std::string hostname;
+
+        /// The constructor
+        SocketEntry(std::string hostname, unsigned port);
+    };
+
+
     protected:
-    /// The addr info
-    std::vector<std::unique_ptr<addrinfo, decltype(&freeaddrinfo)>> _addr;
-    /// The current addr string
-    std::vector<std::pair</*addrAndPort=*/std::string, /*cacheCtr=*/int>> _addrString;
-    /// The ctr
-    unsigned _addrCtr;
+    /// The cache, uses hostname as key, multimap traversals same keys in the insertion order
+    std::multimap<std::string, std::unique_ptr<SocketEntry>> _cache;
+    /// The default priority
+    int _defaultPriority = 8;
 
     public:
-    /// The constructor
-    explicit Cache(unsigned entries);
     /// The address resolving
-    virtual const addrinfo* resolve(std::string hostname, std::string port, bool& oldAddress);
-    /// Reset the current cache bucket
-    void resetBucket() { _addrString[_addrCtr % _addrString.size()].second = 0; }
+    virtual std::unique_ptr<SocketEntry> resolve(std::string hostname, unsigned port, bool tls);
     /// Start the timing and advance to the next cache bucket
-    virtual void startSocket(int /*fd*/) { _addrCtr++; }
-    /// Stop the timing
-    virtual void stopSocket(int /*fd*/, uint64_t /*bytes*/) {}
-    /// Shutdown of the socket should clear the same addresses
-    virtual void shutdownSocket(int /*fd*/) {}
+    virtual void startSocket(int /*fd*/) {}
+    /// Stops the socket and either closes the connection or cashes it
+    virtual void stopSocket(std::unique_ptr<SocketEntry> socketEntry, uint64_t bytes, unsigned cachedEntries, bool reuseSocket);
+    /// Shutdown of the socket and clears the same addresses
+    virtual void shutdownSocket(std::unique_ptr<SocketEntry> socketEntry);
     /// The destructor
-    virtual ~Cache() noexcept = default;
+    virtual ~Cache();
 
     /// Get the tld
     static std::string_view tld(std::string_view domain);

--- a/include/network/cache.hpp
+++ b/include/network/cache.hpp
@@ -20,7 +20,7 @@ namespace network {
 class IOUringSocket;
 //---------------------------------------------------------------------------
 /// The addr resolver and cacher, which is not thread safe
-class Resolver {
+class Cache {
     protected:
     /// The addr info
     std::vector<std::unique_ptr<addrinfo, decltype(&freeaddrinfo)>> _addr;
@@ -31,7 +31,7 @@ class Resolver {
 
     public:
     /// The constructor
-    explicit Resolver(unsigned entries);
+    explicit Cache(unsigned entries);
     /// The address resolving
     virtual const addrinfo* resolve(std::string hostname, std::string port, bool& oldAddress);
     /// Reset the current cache bucket
@@ -43,7 +43,7 @@ class Resolver {
     /// Shutdown of the socket should clear the same addresses
     virtual void shutdownSocket(int /*fd*/) {}
     /// The destructor
-    virtual ~Resolver() noexcept = default;
+    virtual ~Cache() noexcept = default;
 
     /// Get the tld
     static std::string_view tld(std::string_view domain);

--- a/include/network/connection_manager.hpp
+++ b/include/network/connection_manager.hpp
@@ -52,7 +52,7 @@ class ConnectionManager {
         /// The timeout in usec
         int timeout = 500 * 1000;
         /// Reuse sockets
-        int reuse = 0;
+        int reuse = 1;
         /// The kernel timeout parameter
         __kernel_timespec kernelTimeout;
 

--- a/include/network/connection_manager.hpp
+++ b/include/network/connection_manager.hpp
@@ -1,0 +1,118 @@
+#pragma once
+#include "network/resolver.hpp"
+#include <cassert>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <liburing.h>
+//---------------------------------------------------------------------------
+// AnyBlob - Universal Cloud Object Storage Library
+// Dominik Durner, 2024
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+//---------------------------------------------------------------------------
+namespace anyblob {
+namespace network {
+//---------------------------------------------------------------------------
+class TLSConnection;
+class TLSContext;
+//---------------------------------------------------------------------------
+// This class acts as the connection enabler, closer, and main
+// cache for sockets and their optional tls connection.
+// We further add the DNS resolution to the connection manager.
+class ConnectionManager {
+    public:
+    /// The tcp settings
+    struct TCPSettings {
+        /// flag for nonBlocking
+        int nonBlocking = 1;
+        /// flag for noDelay
+        int noDelay = 0;
+        /// flag for recv no wait
+        int recvNoWait = 0;
+        /// flag for keepAlive
+        int keepAlive = 1;
+        /// time for tcp keepIdle
+        int keepIdle = 1;
+        /// time for tcp keepIntvl
+        int keepIntvl = 1;
+        /// probe count
+        int keepCnt = 1;
+        /// recv buffer for tcp
+        int recvBuffer = 0;
+        /// Maximum segment size
+        int mss = 0;
+        /// Reuse port
+        int reusePorts = 0;
+        /// Lingering of tcp packets
+        int linger = 1;
+        /// The timeout in usec
+        int timeout = 500 * 1000;
+        /// Reuse sockets
+        int reuse = 0;
+        /// The kernel timeout parameter
+        __kernel_timespec kernelTimeout;
+
+        TCPSettings() {
+            kernelTimeout.tv_sec = 0;
+            kernelTimeout.tv_nsec = timeout * 1000;
+        }
+    };
+
+    /// The fd socket entry
+    struct SocketEntry {
+        /// The optional tls connection
+        std::unique_ptr<TLSConnection> tls;
+        /// The fd
+        int32_t fd;
+        /// The port
+        unsigned port;
+        /// The hostname
+        std::string hostname;
+
+        SocketEntry(int32_t fd, std::string hostname, unsigned port, std::unique_ptr<TLSConnection> tls);
+    };
+
+    private:
+    /// The socket wrapper
+    std::unique_ptr<IOUringSocket> _socketWrapper;
+    /// The active sockets
+    std::unordered_map<int32_t, std::unique_ptr<SocketEntry>> _fdSockets;
+    /// The fd socket cache, uses hostname as key
+    std::unordered_multimap<std::string, std::unique_ptr<SocketEntry>> _fdCache;
+    /// Resolver
+    std::unordered_map<std::string, std::unique_ptr<Resolver>> _resolverCache;
+    /// The tls context
+    std::unique_ptr<network::TLSContext> _context;
+
+    public:
+    /// The constructor
+    explicit ConnectionManager(unsigned uringEntries, unsigned resolverCacheEntries);
+    /// The destructor
+    ~ConnectionManager();
+
+    /// Creates a new socket connection
+    [[nodiscard]] int32_t connect(std::string hostname, uint32_t port, bool tls, const TCPSettings& tcpSettings, bool useCache = true, int retryLimit = 16);
+    /// Disconnects the socket
+    void disconnect(int32_t fd, std::string hostname = "", uint32_t port = 0, const TCPSettings* tcpSettings = nullptr, uint64_t bytes = 0, bool forceShutdown = false);
+
+    /// Add resolver
+    void addResolver(const std::string& hostname, std::unique_ptr<Resolver> resolver);
+    /// Checks for a timeout
+    bool checkTimeout(int fd, const TCPSettings& settings);
+
+    /// Get the socket
+    IOUringSocket& getSocketConnection() {
+        assert(_socketWrapper);
+        return *_socketWrapper.get();
+    }
+
+    /// Get the tls connection of the fd
+    TLSConnection* getTLSConnection(int32_t fd);
+};
+//---------------------------------------------------------------------------
+}; // namespace network
+}; // namespace anyblob

--- a/include/network/http_message.hpp
+++ b/include/network/http_message.hpp
@@ -14,21 +14,17 @@ namespace network {
 //---------------------------------------------------------------------------
 /// Implements a http message roundtrip
 struct HTTPMessage : public MessageTask {
-    /// The receive chunk size
-    uint64_t chunkSize;
-    /// The tcp settings
-    IOUringSocket::TCPSettings tcpSettings;
     /// HTTP info header
     std::unique_ptr<HttpHelper::Info> info;
 
     /// The constructor
-    HTTPMessage(OriginalMessage* sendingMessage, uint64_t chunkSize);
+    HTTPMessage(OriginalMessage* sendingMessage, ConnectionManager::TCPSettings& tcpSettings, uint32_t chunkSize);
     /// The destructor
     ~HTTPMessage() override = default;
     /// The message excecute callback
-    MessageState execute(IOUringSocket& socket) override;
+    MessageState execute(ConnectionManager& connectionManager) override;
     /// Reset for restart
-    void reset(IOUringSocket& socket, bool aborted);
+    void reset(ConnectionManager& connectionManager, bool aborted);
 };
 //---------------------------------------------------------------------------
 } // namespace network

--- a/include/network/https_message.hpp
+++ b/include/network/https_message.hpp
@@ -13,23 +13,21 @@
 namespace anyblob {
 namespace network {
 //---------------------------------------------------------------------------
-class TLSContext;
-//---------------------------------------------------------------------------
 /// Implements a https message roundtrip
 struct HTTPSMessage : public HTTPMessage {
+    /// The tls layer
+    TLSConnection* tlsLayer;
     /// The fd
-    int fd;
-    /// The TLSLayer
-    std::unique_ptr<TLSConnection> tlsLayer;
+    int32_t fd;
 
     /// The constructor
-    HTTPSMessage(OriginalMessage* sendingMessage, TLSContext& context, uint64_t chunkSize);
+    HTTPSMessage(OriginalMessage* sendingMessage, ConnectionManager::TCPSettings& tcpSettings, uint32_t chunksize);
     /// The destructor
     ~HTTPSMessage() override = default;
     /// The message excecute callback
-    MessageState execute(IOUringSocket& socket) override;
+    MessageState execute(ConnectionManager& connectionManager) override;
     /// Reset for restart
-    void reset(IOUringSocket& socket, bool aborted);
+    void reset(ConnectionManager& socket, bool aborted);
 };
 //---------------------------------------------------------------------------
 } // namespace network

--- a/include/network/original_message.hpp
+++ b/include/network/original_message.hpp
@@ -18,12 +18,18 @@ namespace utils {
 class Timer;
 }; // namespace utils
 //---------------------------------------------------------------------------
+namespace cloud {
+class Provider;
+}; // namespace cloud
+//---------------------------------------------------------------------------
 namespace network {
 //---------------------------------------------------------------------------
 /// This is the original request message struct
 struct OriginalMessage {
     /// The message
     std::unique_ptr<utils::DataVector<uint8_t>> message;
+    /// The provider that knows the address, the port and, optionally signed the messsage
+    cloud::Provider& provider;
     /// The result
     MessageResult result;
 
@@ -36,13 +42,8 @@ struct OriginalMessage {
     /// Optional trace info
     uint64_t traceId;
 
-    /// The hostname
-    std::string hostname;
-    /// The port
-    uint32_t port;
-
     /// The constructor
-    OriginalMessage(std::unique_ptr<utils::DataVector<uint8_t>> message, std::string_view hostname, uint32_t port, uint8_t* receiveBuffer = nullptr, uint64_t bufferSize = 0, uint64_t traceId = 0) : message(std::move(message)), result(receiveBuffer, bufferSize), putData(nullptr), putLength(), traceId(traceId), hostname(hostname), port(port) {}
+    OriginalMessage(std::unique_ptr<utils::DataVector<uint8_t>> message, cloud::Provider& provider, uint8_t* receiveBuffer = nullptr, uint64_t bufferSize = 0, uint64_t traceId = 0) : message(std::move(message)), provider(provider), result(receiveBuffer, bufferSize), putData(nullptr), putLength(), traceId(traceId) {}
 
     /// The destructor
     virtual ~OriginalMessage() = default;
@@ -72,7 +73,7 @@ struct OriginalCallbackMessage : public OriginalMessage {
     Callback callback;
 
     /// The constructor
-    OriginalCallbackMessage(Callback&& callback, std::unique_ptr<utils::DataVector<uint8_t>> message, std::string_view hostname, uint32_t port, uint8_t* receiveBuffer = nullptr, uint64_t bufferSize = 0, uint64_t traceId = 0) : OriginalMessage(std::move(message), hostname, port, receiveBuffer, bufferSize, traceId), callback(std::forward<Callback>(callback)) {}
+    OriginalCallbackMessage(Callback&& callback, std::unique_ptr<utils::DataVector<uint8_t>> message, cloud::Provider& provider, uint8_t* receiveBuffer = nullptr, uint64_t bufferSize = 0, uint64_t traceId = 0) : OriginalMessage(std::move(message), provider, receiveBuffer, bufferSize, traceId), callback(std::forward<Callback>(callback)) {}
 
     /// The destructor
     virtual ~OriginalCallbackMessage() override = default;

--- a/include/network/resolver.hpp
+++ b/include/network/resolver.hpp
@@ -19,7 +19,7 @@ namespace network {
 //---------------------------------------------------------------------------
 class IOUringSocket;
 //---------------------------------------------------------------------------
-/// The addr resolver and cacher
+/// The addr resolver and cacher, which is not thread safe
 class Resolver {
     protected:
     /// The addr info
@@ -33,13 +33,11 @@ class Resolver {
     /// The constructor
     explicit Resolver(unsigned entries);
     /// The address resolving
-    virtual unsigned resolve(std::string hostname, std::string port, bool& oldAddress);
-    /// Increment the addr ctr
-    void increment() { _addrCtr++; }
-    /// Erase the current cache
-    void erase() { _addrString[_addrCtr % _addrString.size()].second = 0; }
-    /// Start the timing
-    virtual void startSocket(int /*fd*/, unsigned /*ipAsInt*/) {}
+    virtual const addrinfo* resolve(std::string hostname, std::string port, bool& oldAddress);
+    /// Reset the current cache bucket
+    void resetBucket() { _addrString[_addrCtr % _addrString.size()].second = 0; }
+    /// Start the timing and advance to the next cache bucket
+    virtual void startSocket(int /*fd*/) { _addrCtr++; }
     /// Stop the timing
     virtual void stopSocket(int /*fd*/, uint64_t /*bytes*/) {}
     /// Shutdown of the socket should clear the same addresses

--- a/include/network/tasked_send_receiver.hpp
+++ b/include/network/tasked_send_receiver.hpp
@@ -33,7 +33,7 @@ namespace network {
 //---------------------------------------------------------------------------
 class TaskedSendReceiver;
 class TaskedSendReceiverHandle;
-class Resolver;
+class Cache;
 struct OriginalMessage;
 //---------------------------------------------------------------------------
 /// Shared submission and completions queue with multiple TaskedSendReceivers
@@ -125,8 +125,8 @@ class TaskedSendReceiver {
     public:
     /// Get the group
     [[nodiscard]] const TaskedSendReceiverGroup* getGroup() const { return &_group; }
-    /// Adds a resolver
-    void addResolver(const std::string& hostname, std::unique_ptr<Resolver> resolver);
+    /// Adds a domain-specific cache
+    void addCache(const std::string& hostname, std::unique_ptr<Cache> cache);
     /// Process local submissions (should be used for sync requests)
     inline void processSync(bool oneQueueInvocation = true) { sendReceive(true, oneQueueInvocation); }
     /// Set the timings

--- a/include/network/tasked_send_receiver.hpp
+++ b/include/network/tasked_send_receiver.hpp
@@ -57,8 +57,6 @@ class TaskedSendReceiverGroup {
     uint64_t _chunkSize;
     /// The queue maximum for each TaskedSendReceiver
     unsigned _concurrentRequests;
-    /// The maximum dns cache size
-    unsigned _cacheEntries = 32;
     /// The TCP settings
     std::unique_ptr<ConnectionManager::TCPSettings> _tcpSettings;
 

--- a/include/network/throughput_cache.hpp
+++ b/include/network/throughput_cache.hpp
@@ -1,9 +1,9 @@
 #pragma once
-// The `ThroughputResolver` depends on gnu stdlib associative containers that are
-// not supported by libcxx. We remove the throughput resolver in its entirety when
+// The `ThroughputCache` depends on gnu stdlib associative containers that are
+// not supported by libcxx. We remove the throughput cache in its entirety when
 // building with libcxx.
 #ifndef ANYBLOB_LIBCXX_COMPAT
-#include "network/resolver.hpp"
+#include "network/cache.hpp"
 #include <chrono>
 #include <ext/pb_ds/assoc_container.hpp>
 #include <ext/pb_ds/tree_policy.hpp>
@@ -20,8 +20,8 @@ namespace anyblob {
 //---------------------------------------------------------------------------
 namespace network {
 //---------------------------------------------------------------------------
-/// Implements the AWS Resolver logic
-class ThroughputResolver : public network::Resolver {
+/// Implements the throughput-based cache logic
+class ThroughputCache : public network::Cache {
     /// Order statistic tree
     typedef __gnu_pbds::tree<
         double,
@@ -43,7 +43,7 @@ class ThroughputResolver : public network::Resolver {
 
     public:
     /// The constructor
-    explicit ThroughputResolver(unsigned cacheEntries);
+    explicit ThroughputCache(unsigned cacheEntries);
     /// The address resolving
     virtual const addrinfo* resolve(std::string hostname, std::string port, bool& reuse) override;
     /// Start the timing
@@ -53,7 +53,7 @@ class ThroughputResolver : public network::Resolver {
     /// Clears the used server from the cache
     virtual void shutdownSocket(int fd) override;
     /// The destructor
-    virtual ~ThroughputResolver() noexcept = default;
+    virtual ~ThroughputCache() noexcept = default;
 };
 //---------------------------------------------------------------------------
 }; // namespace network

--- a/include/network/throughput_cache.hpp
+++ b/include/network/throughput_cache.hpp
@@ -35,7 +35,7 @@ class ThroughputCache : public network::Cache {
     /// The seconds vector as stable ring buffer
     std::vector<double> _throughput;
     /// The map between fd and start time
-    std::unordered_map<int, std::pair<unsigned, std::chrono::steady_clock::time_point>> _fdMap;
+    std::unordered_map<int, std::chrono::steady_clock::time_point> _fdMap;
     /// The seconds vector iterator
     uint64_t _throughputIterator;
     /// The maximum history
@@ -43,17 +43,13 @@ class ThroughputCache : public network::Cache {
 
     public:
     /// The constructor
-    explicit ThroughputCache(unsigned cacheEntries);
-    /// The address resolving
-    virtual const addrinfo* resolve(std::string hostname, std::string port, bool& reuse) override;
-    /// Start the timing
+    explicit ThroughputCache();
+    /// Start the timing and advance to the next cache bucket
     virtual void startSocket(int fd) override;
-    /// Stop the timing
-    virtual void stopSocket(int fd, uint64_t bytes) override;
-    /// Clears the used server from the cache
-    virtual void shutdownSocket(int fd) override;
+    /// Stops the socket and either closes the connection or cashes it
+    virtual void stopSocket(std::unique_ptr<SocketEntry> socketEntry, uint64_t bytes, unsigned cachedEntries, bool reuseSocket) override;
     /// The destructor
-    virtual ~ThroughputCache() noexcept = default;
+    virtual ~ThroughputCache() = default;
 };
 //---------------------------------------------------------------------------
 }; // namespace network

--- a/include/network/throughput_resolver.hpp
+++ b/include/network/throughput_resolver.hpp
@@ -43,11 +43,11 @@ class ThroughputResolver : public network::Resolver {
 
     public:
     /// The constructor
-    explicit ThroughputResolver(unsigned entries);
+    explicit ThroughputResolver(unsigned cacheEntries);
     /// The address resolving
-    virtual unsigned resolve(std::string hostname, std::string port, bool& reuse) override;
+    virtual const addrinfo* resolve(std::string hostname, std::string port, bool& reuse) override;
     /// Start the timing
-    virtual void startSocket(int fd, unsigned ipAsInt) override;
+    virtual void startSocket(int fd) override;
     /// Stop the timing
     virtual void stopSocket(int fd, uint64_t bytes) override;
     /// Clears the used server from the cache

--- a/include/network/transaction.hpp
+++ b/include/network/transaction.hpp
@@ -96,7 +96,7 @@ class Transaction {
     /// Set the provider
     constexpr void setProvider(cloud::Provider* provider) { this->_provider = provider; }
     /// Sends the request messages to the task group
-    void processAsync(network::TaskedSendReceiverGroup& group);
+    bool processAsync(network::TaskedSendReceiverGroup& group);
     /// Processes the request messages
     void processSync(TaskedSendReceiver& sendReceiver);
 

--- a/include/network/transaction.hpp
+++ b/include/network/transaction.hpp
@@ -98,15 +98,15 @@ class Transaction {
     /// Sends the request messages to the task group
     bool processAsync(network::TaskedSendReceiverGroup& group);
     /// Processes the request messages
-    void processSync(TaskedSendReceiver& sendReceiver);
+    void processSync(TaskedSendReceiverHandle& sendReceiverHandle);
 
     /// Function to ensure fresh keys before creating messages
     /// This is needed to ensure valid keys before a message is requested
     /// Simply forward a task send receiver the message function and the args of this message
     template <typename Function>
-    bool verifyKeyRequest(TaskedSendReceiver& sendReceiver, Function&& func) {
+    bool verifyKeyRequest(TaskedSendReceiverHandle& sendReceiverHandle, Function&& func) {
         assert(_provider);
-        _provider->initSecret(sendReceiver);
+        _provider->initSecret(sendReceiverHandle);
         return std::forward<Function>(func)();
     }
 

--- a/include/utils/data_vector.hpp
+++ b/include/utils/data_vector.hpp
@@ -38,14 +38,14 @@ class DataVector {
     }
 
     /// Copy constructor
-    constexpr DataVector(DataVector& rhs) : _capacity(0), _size(0) {
+    constexpr DataVector(DataVector& rhs) : _capacity(0), _size(0), _data(nullptr) {
         reserve(rhs._capacity);
         _size = rhs._size;
         std::memcpy(data(), rhs.data(), size() * sizeof(T));
     }
 
     /// Constructor from other pointers
-    constexpr DataVector(const T* start, const T* end) : _capacity(0), _size(0) {
+    constexpr DataVector(const T* start, const T* end) : _capacity(0), _size(0), _data(nullptr) {
         assert(end - start >= 0);
         resize(static_cast<uint64_t>(end - start));
         std::memcpy(data(), start, size() * sizeof(T));

--- a/include/utils/unordered_map.hpp
+++ b/include/utils/unordered_map.hpp
@@ -117,8 +117,7 @@ class UnorderedMap {
 
         /// The advance function of the forward iterator
         constexpr Iterator& operator++() {
-            /// TODO: durner
-            return *this;
+            throw std::runtime_error("advancing an iterator is not implemented");
         }
     };
 

--- a/include/utils/utils.hpp
+++ b/include/utils/utils.hpp
@@ -12,6 +12,12 @@
 namespace anyblob {
 namespace utils {
 //---------------------------------------------------------------------------
+#ifndef NDEBUG
+#define verify(expression) assert(expression)
+#else
+#define verify(expression) ((void) (expression))
+#endif
+//---------------------------------------------------------------------------
 /// Encode url special characters in %HEX
 std::string encodeUrlParameters(const std::string& encode);
 /// Encode everything from binary representation to hex

--- a/src/cloud/aws.cpp
+++ b/src/cloud/aws.cpp
@@ -1,5 +1,5 @@
 #include "cloud/aws.hpp"
-#include "cloud/aws_resolver.hpp"
+#include "cloud/aws_cache.hpp"
 #include "cloud/http.hpp"
 #include "network/http_helper.hpp"
 #include "network/original_message.hpp"
@@ -304,12 +304,12 @@ void AWS::getSecret()
     }
 }
 //---------------------------------------------------------------------------
-void AWS::initResolver(network::TaskedSendReceiverHandle& sendReceiverHandle)
-// Inits the resolver
+void AWS::initCache(network::TaskedSendReceiverHandle& sendReceiverHandle)
+// Inits the cache
 {
     assert(sendReceiverHandle.get());
     if (_type == Provider::CloudService::AWS) {
-        sendReceiverHandle.get()->addResolver("amazonaws.com", unique_ptr<network::Resolver>(new cloud::AWSResolver(sendReceiverHandle.getGroup()->getConcurrentRequests())));
+        sendReceiverHandle.get()->addCache("amazonaws.com", unique_ptr<network::Cache>(new cloud::AWSCache(sendReceiverHandle.getGroup()->getConcurrentRequests())));
     }
 }
 //---------------------------------------------------------------------------

--- a/src/cloud/aws.cpp
+++ b/src/cloud/aws.cpp
@@ -5,6 +5,7 @@
 #include "network/original_message.hpp"
 #include "network/tasked_send_receiver.hpp"
 #include "utils/data_vector.hpp"
+#include "utils/utils.hpp"
 #include <chrono>
 #include <iomanip>
 #include <sstream>
@@ -63,8 +64,8 @@ Provider::Instance AWS::getInstanceDetails(network::TaskedSendReceiverHandle& se
         info.port = getIAMPort();
         HTTP http(info);
         auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-        assert(sendReceiverHandle.sendSync(originalMsg.get()));
-        assert(sendReceiverHandle.processSync());
+        verify(sendReceiverHandle.sendSync(originalMsg.get()));
+        verify(sendReceiverHandle.processSync());
         auto& content = originalMsg->result.getDataVector();
         unique_ptr<network::HttpHelper::Info> infoPtr;
         auto s = network::HttpHelper::retrieveContent(content.cdata(), content.size(), infoPtr);
@@ -87,8 +88,8 @@ string AWS::getInstanceRegion(network::TaskedSendReceiverHandle& sendReceiverHan
     info.port = getIAMPort();
     HTTP http(info);
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-    assert(sendReceiverHandle.sendSync(originalMsg.get()));
-    assert(sendReceiverHandle.processSync());
+    verify(sendReceiverHandle.sendSync(originalMsg.get()));
+    verify(sendReceiverHandle.processSync());
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HttpHelper::Info> infoPtr;
     auto s = network::HttpHelper::retrieveContent(content.cdata(), content.size(), infoPtr);
@@ -243,16 +244,16 @@ void AWS::initSecret(network::TaskedSendReceiverHandle& sendReceiverHandle)
                 info.port = getIAMPort();
                 HTTP http(info);
                 auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-                assert(sendReceiverHandle.sendSync(originalMsg.get()));
-                assert(sendReceiverHandle.processSync());
+                verify(sendReceiverHandle.sendSync(originalMsg.get()));
+                verify(sendReceiverHandle.processSync());
                 auto& content = originalMsg->result.getDataVector();
                 unique_ptr<network::HttpHelper::Info> infoPtr;
                 auto s = network::HttpHelper::retrieveContent(content.cdata(), content.size(), infoPtr);
                 string iamUser;
                 message = downloadSecret(s, iamUser);
                 originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-                assert(sendReceiverHandle.sendSync(originalMsg.get()));
-                assert(sendReceiverHandle.processSync());
+                verify(sendReceiverHandle.sendSync(originalMsg.get()));
+                verify(sendReceiverHandle.processSync());
                 auto& secretContent = originalMsg->result.getDataVector();
                 infoPtr.reset();
                 s = network::HttpHelper::retrieveContent(secretContent.cdata(), secretContent.size(), infoPtr);
@@ -277,8 +278,8 @@ void AWS::initSecret(network::TaskedSendReceiverHandle& sendReceiverHandle)
                 info.port = getPort();
                 HTTP http(info);
                 auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-                assert(sendReceiverHandle.sendSync(originalMsg.get()));
-                assert(sendReceiverHandle.processSync());
+                verify(sendReceiverHandle.sendSync(originalMsg.get()));
+                verify(sendReceiverHandle.processSync());
                 auto& secretContent = originalMsg->result.getDataVector();
                 unique_ptr<network::HttpHelper::Info> infoPtr;
                 auto s = network::HttpHelper::retrieveContent(secretContent.cdata(), secretContent.size(), infoPtr);
@@ -309,7 +310,7 @@ void AWS::initCache(network::TaskedSendReceiverHandle& sendReceiverHandle)
 {
     assert(sendReceiverHandle.get());
     if (_type == Provider::CloudService::AWS) {
-        sendReceiverHandle.get()->addCache("amazonaws.com", unique_ptr<network::Cache>(new cloud::AWSCache(sendReceiverHandle.getGroup()->getConcurrentRequests())));
+        sendReceiverHandle.get()->addCache("amazonaws.com", unique_ptr<network::Cache>(new cloud::AWSCache()));
     }
 }
 //---------------------------------------------------------------------------

--- a/src/cloud/aws.cpp
+++ b/src/cloud/aws.cpp
@@ -233,8 +233,10 @@ void AWS::initSecret(network::TaskedSendReceiver& sendReceiver)
         while (true) {
             if (_mutex.try_lock()) {
                 _secret = _globalSecret;
-                if (validKeys(180))
+                if (validKeys(180)) {
+                    _mutex.unlock();
                     return;
+                }
                 auto message = downloadIAMUser();
                 RemoteInfo info;
                 info.endpoint = getIAMAddress();
@@ -265,9 +267,10 @@ void AWS::initSecret(network::TaskedSendReceiver& sendReceiver)
         while (true) {
             if (_mutex.try_lock()) {
                 _sessionSecret = _globalSessionSecret;
-                if (validSession(180))
+                if (validKeys(180)) {
+                    _mutex.unlock();
                     return;
-
+                }
                 auto message = getSessionToken();
                 RemoteInfo info;
                 info.endpoint = _settings.bucket + ".s3.amazonaws.com";

--- a/src/cloud/aws_resolver.cpp
+++ b/src/cloud/aws_resolver.cpp
@@ -23,7 +23,7 @@ AWSResolver::AWSResolver(unsigned entries) : Resolver(entries), _mtuCache()
 {
 }
 //---------------------------------------------------------------------------
-unsigned AWSResolver::resolve(string hostname, string port, bool& oldAddress)
+const addrinfo* AWSResolver::resolve(string hostname, string port, bool& oldAddress)
 // Resolve the request
 {
     auto addrPos = _addrCtr % static_cast<unsigned>(_addrString.size());
@@ -70,7 +70,7 @@ unsigned AWSResolver::resolve(string hostname, string port, bool& oldAddress)
         }
         oldAddress = false;
     }
-    return addrPos;
+    return _addr[addrPos].get();
 }
 //---------------------------------------------------------------------------
 }; // namespace cloud

--- a/src/cloud/azure.cpp
+++ b/src/cloud/azure.cpp
@@ -3,7 +3,7 @@
 #include "cloud/http.hpp"
 #include "network/http_helper.hpp"
 #include "network/original_message.hpp"
-#include "network/resolver.hpp"
+#include "network/cache.hpp"
 #include "network/tasked_send_receiver.hpp"
 #include "utils/data_vector.hpp"
 #include <algorithm>

--- a/src/cloud/azure.cpp
+++ b/src/cloud/azure.cpp
@@ -6,6 +6,7 @@
 #include "network/cache.hpp"
 #include "network/tasked_send_receiver.hpp"
 #include "utils/data_vector.hpp"
+#include "utils/utils.hpp"
 #include <algorithm>
 #include <chrono>
 #include <iomanip>
@@ -57,8 +58,8 @@ Provider::Instance Azure::getInstanceDetails(network::TaskedSendReceiverHandle& 
     info.port = getIAMPort();
     HTTP http(info);
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-    assert(sendReceiverHandle.sendSync(originalMsg.get()));
-    assert(sendReceiverHandle.processSync());
+    verify(sendReceiverHandle.sendSync(originalMsg.get()));
+    verify(sendReceiverHandle.processSync());
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HttpHelper::Info> infoPtr;
     auto s = network::HttpHelper::retrieveContent(content.cdata(), content.size(), infoPtr);
@@ -86,8 +87,8 @@ string Azure::getRegion(network::TaskedSendReceiverHandle& sendReceiverHandle)
     info.port = getIAMPort();
     HTTP http(info);
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-    assert(sendReceiverHandle.sendSync(originalMsg.get()));
-    assert(sendReceiverHandle.processSync());
+    verify(sendReceiverHandle.sendSync(originalMsg.get()));
+    verify(sendReceiverHandle.processSync());
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HttpHelper::Info> infoPtr;
     auto s = network::HttpHelper::retrieveContent(content.cdata(), content.size(), infoPtr);

--- a/src/cloud/azure.cpp
+++ b/src/cloud/azure.cpp
@@ -1,9 +1,10 @@
 #include "cloud/azure.hpp"
 #include "cloud/azure_signer.hpp"
+#include "cloud/http.hpp"
 #include "network/http_helper.hpp"
 #include "network/original_message.hpp"
-#include "network/tasked_send_receiver.hpp"
 #include "network/resolver.hpp"
+#include "network/tasked_send_receiver.hpp"
 #include "utils/data_vector.hpp"
 #include <algorithm>
 #include <chrono>
@@ -51,7 +52,11 @@ Provider::Instance Azure::getInstanceDetails(network::TaskedSendReceiver& sendRe
 // Uses the send receiver to initialize the secret
 {
     auto message = downloadInstanceInfo();
-    auto originalMsg = make_unique<network::OriginalMessage>(move(message), getIAMAddress(), getIAMPort());
+    RemoteInfo info;
+    info.endpoint = getIAMAddress();
+    info.port = getIAMPort();
+    HTTP http(info);
+    auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
     sendReceiver.sendSync(originalMsg.get());
     sendReceiver.processSync();
     auto& content = originalMsg->result.getDataVector();
@@ -76,7 +81,11 @@ string Azure::getRegion(network::TaskedSendReceiver& sendReceiver)
 // Uses the send receiver to initialize the secret
 {
     auto message = downloadInstanceInfo();
-    auto originalMsg = make_unique<network::OriginalMessage>(move(message), getIAMAddress(), getIAMPort());
+    RemoteInfo info;
+    info.endpoint = getIAMAddress();
+    info.port = getIAMPort();
+    HTTP http(info);
+    auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
     sendReceiver.sendSync(originalMsg.get());
     sendReceiver.processSync();
     auto& content = originalMsg->result.getDataVector();

--- a/src/cloud/azure.cpp
+++ b/src/cloud/azure.cpp
@@ -48,7 +48,7 @@ unique_ptr<utils::DataVector<uint8_t>> Azure::downloadInstanceInfo()
     return make_unique<utils::DataVector<uint8_t>>(reinterpret_cast<uint8_t*>(httpHeader.data()), reinterpret_cast<uint8_t*>(httpHeader.data() + httpHeader.size()));
 }
 //---------------------------------------------------------------------------
-Provider::Instance Azure::getInstanceDetails(network::TaskedSendReceiver& sendReceiver)
+Provider::Instance Azure::getInstanceDetails(network::TaskedSendReceiverHandle& sendReceiverHandle)
 // Uses the send receiver to initialize the secret
 {
     auto message = downloadInstanceInfo();
@@ -57,8 +57,8 @@ Provider::Instance Azure::getInstanceDetails(network::TaskedSendReceiver& sendRe
     info.port = getIAMPort();
     HTTP http(info);
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-    sendReceiver.sendSync(originalMsg.get());
-    sendReceiver.processSync();
+    assert(sendReceiverHandle.sendSync(originalMsg.get()));
+    assert(sendReceiverHandle.processSync());
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HttpHelper::Info> infoPtr;
     auto s = network::HttpHelper::retrieveContent(content.cdata(), content.size(), infoPtr);
@@ -77,7 +77,7 @@ Provider::Instance Azure::getInstanceDetails(network::TaskedSendReceiver& sendRe
     return AzureInstance{string(s), 0, 0, 0};
 }
 //---------------------------------------------------------------------------
-string Azure::getRegion(network::TaskedSendReceiver& sendReceiver)
+string Azure::getRegion(network::TaskedSendReceiverHandle& sendReceiverHandle)
 // Uses the send receiver to initialize the secret
 {
     auto message = downloadInstanceInfo();
@@ -86,8 +86,8 @@ string Azure::getRegion(network::TaskedSendReceiver& sendReceiver)
     info.port = getIAMPort();
     HTTP http(info);
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-    sendReceiver.sendSync(originalMsg.get());
-    sendReceiver.processSync();
+    assert(sendReceiverHandle.sendSync(originalMsg.get()));
+    assert(sendReceiverHandle.processSync());
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HttpHelper::Info> infoPtr;
     auto s = network::HttpHelper::retrieveContent(content.cdata(), content.size(), infoPtr);

--- a/src/cloud/gcp.cpp
+++ b/src/cloud/gcp.cpp
@@ -3,7 +3,7 @@
 #include "cloud/gcp_signer.hpp"
 #include "network/http_helper.hpp"
 #include "network/original_message.hpp"
-#include "network/resolver.hpp"
+#include "network/cache.hpp"
 #include "network/tasked_send_receiver.hpp"
 #include "utils/data_vector.hpp"
 #include <chrono>

--- a/src/cloud/gcp.cpp
+++ b/src/cloud/gcp.cpp
@@ -41,7 +41,7 @@ unique_ptr<utils::DataVector<uint8_t>> GCP::downloadInstanceInfo(const string& i
     return make_unique<utils::DataVector<uint8_t>>(reinterpret_cast<uint8_t*>(httpHeader.data()), reinterpret_cast<uint8_t*>(httpHeader.data() + httpHeader.size()));
 }
 //---------------------------------------------------------------------------
-Provider::Instance GCP::getInstanceDetails(network::TaskedSendReceiver& sendReceiver)
+Provider::Instance GCP::getInstanceDetails(network::TaskedSendReceiverHandle& sendReceiverHandle)
 // Uses the send receiver to initialize the secret
 {
     auto message = downloadInstanceInfo();
@@ -50,8 +50,8 @@ Provider::Instance GCP::getInstanceDetails(network::TaskedSendReceiver& sendRece
     info.port = getIAMPort();
     HTTP http(info);
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-    sendReceiver.sendSync(originalMsg.get());
-    sendReceiver.processSync();
+    assert(sendReceiverHandle.sendSync(originalMsg.get()));
+    assert(sendReceiverHandle.processSync());
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HttpHelper::Info> infoPtr;
     auto s = network::HttpHelper::retrieveContent(content.cdata(), content.size(), infoPtr);
@@ -64,7 +64,7 @@ Provider::Instance GCP::getInstanceDetails(network::TaskedSendReceiver& sendRece
     return GCPInstance{string(s), 0, 0, 0};
 }
 //---------------------------------------------------------------------------
-string GCP::getInstanceRegion(network::TaskedSendReceiver& sendReceiver)
+string GCP::getInstanceRegion(network::TaskedSendReceiverHandle& sendReceiverHandle)
 // Uses the send receiver to initialize the secret
 {
     auto message = downloadInstanceInfo("zone");
@@ -73,8 +73,8 @@ string GCP::getInstanceRegion(network::TaskedSendReceiver& sendReceiver)
     info.port = getIAMPort();
     HTTP http(info);
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-    sendReceiver.sendSync(originalMsg.get());
-    sendReceiver.processSync();
+    assert(sendReceiverHandle.sendSync(originalMsg.get()));
+    assert(sendReceiverHandle.processSync());
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HttpHelper::Info> infoPtr;
     auto s = network::HttpHelper::retrieveContent(content.cdata(), content.size(), infoPtr);

--- a/src/cloud/gcp.cpp
+++ b/src/cloud/gcp.cpp
@@ -6,6 +6,7 @@
 #include "network/cache.hpp"
 #include "network/tasked_send_receiver.hpp"
 #include "utils/data_vector.hpp"
+#include "utils/utils.hpp"
 #include <chrono>
 #include <iomanip>
 #include <sstream>
@@ -50,8 +51,8 @@ Provider::Instance GCP::getInstanceDetails(network::TaskedSendReceiverHandle& se
     info.port = getIAMPort();
     HTTP http(info);
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-    assert(sendReceiverHandle.sendSync(originalMsg.get()));
-    assert(sendReceiverHandle.processSync());
+    verify(sendReceiverHandle.sendSync(originalMsg.get()));
+    verify(sendReceiverHandle.processSync());
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HttpHelper::Info> infoPtr;
     auto s = network::HttpHelper::retrieveContent(content.cdata(), content.size(), infoPtr);
@@ -73,8 +74,8 @@ string GCP::getInstanceRegion(network::TaskedSendReceiverHandle& sendReceiverHan
     info.port = getIAMPort();
     HTTP http(info);
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
-    assert(sendReceiverHandle.sendSync(originalMsg.get()));
-    assert(sendReceiverHandle.processSync());
+    verify(sendReceiverHandle.sendSync(originalMsg.get()));
+    verify(sendReceiverHandle.processSync());
     auto& content = originalMsg->result.getDataVector();
     unique_ptr<network::HttpHelper::Info> infoPtr;
     auto s = network::HttpHelper::retrieveContent(content.cdata(), content.size(), infoPtr);

--- a/src/cloud/gcp.cpp
+++ b/src/cloud/gcp.cpp
@@ -1,4 +1,5 @@
 #include "cloud/gcp.hpp"
+#include "cloud/http.hpp"
 #include "cloud/gcp_signer.hpp"
 #include "network/http_helper.hpp"
 #include "network/original_message.hpp"
@@ -44,7 +45,11 @@ Provider::Instance GCP::getInstanceDetails(network::TaskedSendReceiver& sendRece
 // Uses the send receiver to initialize the secret
 {
     auto message = downloadInstanceInfo();
-    auto originalMsg = make_unique<network::OriginalMessage>(move(message), getIAMAddress(), getIAMPort());
+    RemoteInfo info;
+    info.endpoint = getIAMAddress();
+    info.port = getIAMPort();
+    HTTP http(info);
+    auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
     sendReceiver.sendSync(originalMsg.get());
     sendReceiver.processSync();
     auto& content = originalMsg->result.getDataVector();
@@ -63,7 +68,11 @@ string GCP::getInstanceRegion(network::TaskedSendReceiver& sendReceiver)
 // Uses the send receiver to initialize the secret
 {
     auto message = downloadInstanceInfo("zone");
-    auto originalMsg = make_unique<network::OriginalMessage>(move(message), getIAMAddress(), getIAMPort());
+    RemoteInfo info;
+    info.endpoint = getIAMAddress();
+    info.port = getIAMPort();
+    HTTP http(info);
+    auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
     sendReceiver.sendSync(originalMsg.get());
     sendReceiver.processSync();
     auto& content = originalMsg->result.getDataVector();

--- a/src/cloud/http.cpp
+++ b/src/cloud/http.cpp
@@ -98,7 +98,7 @@ string HTTP::getAddress() const
     return _settings.hostname;
 }
 //---------------------------------------------------------------------------
-Provider::Instance HTTP::getInstanceDetails(network::TaskedSendReceiver& /*sendReceiver*/)
+Provider::Instance HTTP::getInstanceDetails(network::TaskedSendReceiverHandle& /*sendReceiver*/)
 // No real information for HTTP
 {
     return Instance{"http", 0, 0, 0};

--- a/src/cloud/http.cpp
+++ b/src/cloud/http.cpp
@@ -1,0 +1,108 @@
+#include "cloud/http.hpp"
+#include "network/http_request.hpp"
+#include "utils/data_vector.hpp"
+#include <string>
+#include <sstream>
+//---------------------------------------------------------------------------
+// AnyBlob - Universal Cloud Object Storage Library
+// Dominik Durner, 2024
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+//---------------------------------------------------------------------------
+namespace anyblob {
+namespace cloud {
+//---------------------------------------------------------------------------
+using namespace std;
+//---------------------------------------------------------------------------
+unique_ptr<utils::DataVector<uint8_t>> HTTP::getRequest(const string& filePath, const pair<uint64_t, uint64_t>& range) const
+// Builds the http request for downloading a blob
+{
+    network::HttpRequest request;
+    request.method = network::HttpRequest::Method::GET;
+    request.type = network::HttpRequest::Type::HTTP_1_1;
+    request.path = "/" + filePath;
+
+    request.headers.emplace("Host", getAddress());
+    if (range.first != range.second) {
+        stringstream rangeString;
+        rangeString << "bytes=" << range.first << "-" << range.second;
+        request.headers.emplace("Range", rangeString.str());
+    }
+
+    string httpHeader = network::HttpRequest::getRequestMethod(request.method);
+    httpHeader += " " + request.path + " ";
+    httpHeader += network::HttpRequest::getRequestType(request.type);
+    httpHeader += "\r\n";
+    for (const auto& h : request.headers)
+        httpHeader += h.first + ": " + h.second + "\r\n";
+    httpHeader += "\r\n";
+
+    return make_unique<utils::DataVector<uint8_t>>(reinterpret_cast<uint8_t*>(httpHeader.data()), reinterpret_cast<uint8_t*>(httpHeader.data() + httpHeader.size()));
+}
+//---------------------------------------------------------------------------
+unique_ptr<utils::DataVector<uint8_t>> HTTP::putRequest(const string& filePath, string_view object) const
+// Builds the http request for putting objects without the object data itself
+{
+    network::HttpRequest request;
+    request.method = network::HttpRequest::Method::PUT;
+    request.type = network::HttpRequest::Type::HTTP_1_1;
+    request.path = "/" + filePath;
+    auto bodyLength = object.size();
+
+    request.headers.emplace("Host", getAddress());
+    request.headers.emplace("Content-Length", to_string(bodyLength));
+
+    string httpHeader = network::HttpRequest::getRequestMethod(request.method);
+    httpHeader += " " + request.path + " ";
+    httpHeader += network::HttpRequest::getRequestType(request.type);
+    httpHeader += "\r\n";
+    for (const auto& h : request.headers)
+        httpHeader += h.first + ": " + h.second + "\r\n";
+    httpHeader += "\r\n";
+
+    return make_unique<utils::DataVector<uint8_t>>(reinterpret_cast<uint8_t*>(httpHeader.data()), reinterpret_cast<uint8_t*>(httpHeader.data() + httpHeader.size()));
+}
+//---------------------------------------------------------------------------
+unique_ptr<utils::DataVector<uint8_t>> HTTP::deleteRequest(const string& filePath) const
+// Builds the http request for deleting objects
+{
+    network::HttpRequest request;
+    request.method = network::HttpRequest::Method::DELETE;
+    request.type = network::HttpRequest::Type::HTTP_1_1;
+    request.path = "/" + filePath;
+
+    request.headers.emplace("Host", getAddress());
+
+    string httpHeader = network::HttpRequest::getRequestMethod(request.method);
+    httpHeader += " " + request.path + " ";
+    httpHeader += network::HttpRequest::getRequestType(request.type);
+    httpHeader += "\r\n";
+    for (const auto& h : request.headers)
+        httpHeader += h.first + ": " + h.second + "\r\n";
+    httpHeader += "\r\n";
+
+    return make_unique<utils::DataVector<uint8_t>>(reinterpret_cast<uint8_t*>(httpHeader.data()), reinterpret_cast<uint8_t*>(httpHeader.data() + httpHeader.size()));
+}
+//---------------------------------------------------------------------------
+uint32_t HTTP::getPort() const
+// Gets the port of Azure on http
+{
+    return _settings.port;
+}
+//---------------------------------------------------------------------------
+string HTTP::getAddress() const
+// Gets the address of Azure
+{
+    return _settings.hostname;
+}
+//---------------------------------------------------------------------------
+Provider::Instance HTTP::getInstanceDetails(network::TaskedSendReceiver& /*sendReceiver*/)
+// No real information for HTTP
+{
+    return Instance{"http", 0, 0, 0};
+}
+//---------------------------------------------------------------------------
+} // namespace cloud
+} // namespace anyblob

--- a/src/cloud/ibm.cpp
+++ b/src/cloud/ibm.cpp
@@ -14,7 +14,7 @@ namespace cloud {
 //---------------------------------------------------------------------------
 using namespace std;
 //---------------------------------------------------------------------------
-Provider::Instance IBM::getInstanceDetails(network::TaskedSendReceiver& /*sendReceiver*/)
+Provider::Instance IBM::getInstanceDetails(network::TaskedSendReceiverHandle& /*sendReceiver*/)
 // IBM instance info
 {
     // TODO: add instances and retrieve VM information

--- a/src/cloud/minio.cpp
+++ b/src/cloud/minio.cpp
@@ -13,7 +13,7 @@ namespace cloud {
 //---------------------------------------------------------------------------
 using namespace std;
 //---------------------------------------------------------------------------
-Provider::Instance MinIO::getInstanceDetails(network::TaskedSendReceiver& /*sendReceiver*/)
+Provider::Instance MinIO::getInstanceDetails(network::TaskedSendReceiverHandle& /*sendReceiver*/)
 // No real information for MinIO
 {
     return AWSInstance{"minio", 0, 0, 0};

--- a/src/cloud/oracle.cpp
+++ b/src/cloud/oracle.cpp
@@ -14,7 +14,7 @@ namespace cloud {
 //---------------------------------------------------------------------------
 using namespace std;
 //---------------------------------------------------------------------------
-Provider::Instance Oracle::getInstanceDetails(network::TaskedSendReceiver& /*sendReceiver*/)
+Provider::Instance Oracle::getInstanceDetails(network::TaskedSendReceiverHandle& /*sendReceiver*/)
 // Get the instance details
 {
     // TODO: add instances and retrieve shape information

--- a/src/cloud/provider.cpp
+++ b/src/cloud/provider.cpp
@@ -188,14 +188,14 @@ unique_ptr<utils::DataVector<uint8_t>> Provider::resignRequest(const utils::Data
     return nullptr;
 }
 //---------------------------------------------------------------------------
-network::Config Provider::getConfig(network::TaskedSendReceiver& sendReceiver)
+network::Config Provider::getConfig(network::TaskedSendReceiverHandle& sendReceiverHandle)
 // Uses the send receiver to get instance configs
 {
-    auto instance = getInstanceDetails(sendReceiver);
+    auto instance = getInstanceDetails(sendReceiverHandle);
     return network::Config{network::Config::defaultCoreThroughput, network::Config::defaultCoreConcurrency, instance.network};
 }
 //---------------------------------------------------------------------------
-unique_ptr<Provider> Provider::makeProvider(const string& filepath, bool https, const string& keyId, const string& secret, network::TaskedSendReceiver* sendReceiver)
+unique_ptr<Provider> Provider::makeProvider(const string& filepath, bool https, const string& keyId, const string& secret, network::TaskedSendReceiverHandle* sendReceiverHandle)
 // Create a provider
 {
     auto info = anyblob::cloud::Provider::getRemoteInfo(filepath);
@@ -203,20 +203,20 @@ unique_ptr<Provider> Provider::makeProvider(const string& filepath, bool https, 
         info.port = 443;
     switch (info.provider) {
         case anyblob::cloud::Provider::CloudService::AWS: {
-            if (sendReceiver && info.region.empty())
-                info.region = anyblob::cloud::AWS::getInstanceRegion(*sendReceiver);
+            if (sendReceiverHandle && info.region.empty())
+                info.region = anyblob::cloud::AWS::getInstanceRegion(*sendReceiverHandle);
 
             if (keyId.empty()) {
                 auto aws = make_unique<anyblob::cloud::AWS>(info);
-                aws->initSecret(*sendReceiver);
+                aws->initSecret(*sendReceiverHandle);
                 return aws;
             }
             auto aws = make_unique<anyblob::cloud::AWS>(info, keyId, secret);
             return aws;
         }
         case anyblob::cloud::Provider::CloudService::GCP: {
-            if (sendReceiver && info.region.empty())
-                info.region = anyblob::cloud::GCP::getInstanceRegion(*sendReceiver);
+            if (sendReceiverHandle && info.region.empty())
+                info.region = anyblob::cloud::GCP::getInstanceRegion(*sendReceiverHandle);
             auto gcp = make_unique<anyblob::cloud::GCP>(info, keyId, secret);
             return gcp;
         }

--- a/src/cloud/provider.cpp
+++ b/src/cloud/provider.cpp
@@ -182,6 +182,12 @@ unique_ptr<utils::DataVector<uint8_t>> Provider::completeMultiPartRequest(const 
     return nullptr;
 }
 //---------------------------------------------------------------------------
+unique_ptr<utils::DataVector<uint8_t>> Provider::resignRequest(const utils::DataVector<uint8_t>& /*data*/, const uint8_t* /*bodyData*/, uint64_t /*bodyLength*/) const
+// Resigned header
+{
+    return nullptr;
+}
+//---------------------------------------------------------------------------
 network::Config Provider::getConfig(network::TaskedSendReceiver& sendReceiver)
 // Uses the send receiver to get instance configs
 {

--- a/src/network/cache.cpp
+++ b/src/network/cache.cpp
@@ -1,8 +1,7 @@
-#include "cloud/aws_resolver.hpp"
+#include "network/cache.hpp"
 #include <cstring>
 #include <limits>
 #include <stdexcept>
-#include <string>
 #include <arpa/inet.h>
 #include <sys/types.h>
 //---------------------------------------------------------------------------
@@ -14,22 +13,41 @@
 // SPDX-License-Identifier: MPL-2.0
 //---------------------------------------------------------------------------
 namespace anyblob {
-namespace cloud {
+namespace network {
 //---------------------------------------------------------------------------
 using namespace std;
 //---------------------------------------------------------------------------
-AWSResolver::AWSResolver(unsigned entries) : Resolver(entries), _mtuCache()
-// Constructor
+string_view Cache::tld(string_view domain)
+// String prefix
 {
+    auto pos = domain.find_last_of('.');
+    if (pos != string::npos) {
+        pos = domain.substr(0, pos - 1).find_last_of('.');
+        if (pos == string::npos)
+            return domain;
+        else
+            return string_view(domain).substr(pos + 1, domain.size());
+    }
+    return string_view();
 }
 //---------------------------------------------------------------------------
-const addrinfo* AWSResolver::resolve(string hostname, string port, bool& oldAddress)
+Cache::Cache(unsigned entries)
+// Constructor
+{
+    _addr.reserve(entries);
+    for (auto i = 0u; i < entries; i++) {
+        _addr.emplace_back(nullptr, &freeaddrinfo);
+    }
+    _addrString.resize(entries, {"", 0});
+    _addrCtr = 0;
+}
+//---------------------------------------------------------------------------
+const addrinfo* Cache::resolve(string hostname, string port, bool& oldAddress)
 // Resolve the request
 {
     auto addrPos = _addrCtr % static_cast<unsigned>(_addrString.size());
     auto curCtr = _addrString[addrPos].second--;
     auto hostString = hostname + ":" + port;
-    // Reuses old address
     oldAddress = true;
     if (_addrString[addrPos].first.compare(hostString) || curCtr == 0) {
         struct addrinfo hints = {};
@@ -39,40 +57,16 @@ const addrinfo* AWSResolver::resolve(string hostname, string port, bool& oldAddr
         hints.ai_protocol = IPPROTO_TCP;
 
         addrinfo* temp;
-        if (getaddrinfo(hostname.c_str(), port.c_str(), &hints, &temp)) {
+        if (getaddrinfo(hostname.c_str(), port.c_str(), &hints, &temp) != 0) {
             throw runtime_error("hostname getaddrinfo error");
         }
         _addr[addrPos].reset(temp);
-        if (!Resolver::tld(hostname).compare("amazonaws.com")) {
-            struct sockaddr_in* p = reinterpret_cast<sockaddr_in*>(_addr[addrPos]->ai_addr);
-            auto ipAsInt = p->sin_addr.s_addr;
-            auto it = _mtuCache.find(ipAsInt);
-            if (it != _mtuCache.end()) {
-                if (it->second)
-                    _addrString[addrPos] = {move(hostString), numeric_limits<int>::max()};
-                else
-                    _addrString[addrPos] = {move(hostString), 12};
-            } else {
-                char ipv4[INET_ADDRSTRLEN];
-                inet_ntop(AF_INET, &p->sin_addr, ipv4, INET_ADDRSTRLEN);
-                string cmd = "timeout 0.01 ping -s 1473 -D " + string(ipv4) + " -c 1 >>/dev/null 2>>/dev/null";
-                auto res = system(cmd.c_str());
-                if (!res) {
-                    _mtuCache.emplace(ipAsInt, true);
-                    _addrString[addrPos] = {move(hostString), numeric_limits<int>::max()};
-                } else {
-                    _mtuCache.emplace(ipAsInt, false);
-                    _addrString[addrPos] = {move(hostString), 12};
-                }
-            }
-        } else {
-            _addrString[addrPos] = {move(hostString), 12};
-        }
+        _addrString[addrPos] = {move(hostString), 12};
         oldAddress = false;
     }
     return _addr[addrPos].get();
 }
 //---------------------------------------------------------------------------
-}; // namespace cloud
+}; // namespace network
 //---------------------------------------------------------------------------
 }; // namespace anyblob

--- a/src/network/connection_manager.cpp
+++ b/src/network/connection_manager.cpp
@@ -1,0 +1,328 @@
+#include "network/connection_manager.hpp"
+#include "network/io_uring_socket.hpp"
+#include "network/tls_connection.hpp"
+#include "network/tls_context.hpp"
+#ifndef ANYBLOB_LIBCXX_COMPAT
+#include "network/throughput_resolver.hpp"
+#endif
+#include <cassert>
+#include <cstring>
+#include <string>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdlib.h>
+#include <sys/eventfd.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+//---------------------------------------------------------------------------
+// AnyBlob - Universal Cloud Object Storage Library
+// Dominik Durner, 2024
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+//---------------------------------------------------------------------------
+namespace anyblob {
+namespace network {
+//---------------------------------------------------------------------------
+using namespace std;
+//---------------------------------------------------------------------------
+ConnectionManager::SocketEntry::SocketEntry(int32_t fd, std::string hostname, unsigned port, std::unique_ptr<TLSConnection> tls) : tls(move(tls)), fd(fd), port(port), hostname(move(hostname))
+// The constructor
+{}
+//---------------------------------------------------------------------------
+ConnectionManager::ConnectionManager(unsigned uringEntries, unsigned resolverCacheEntries) : _socketWrapper(make_unique<IOUringSocket>(uringEntries)), _resolverCache()
+// The constructor
+{
+    _context = make_unique<network::TLSContext>();
+#ifndef ANYBLOB_LIBCXX_COMPAT
+    // By default, use the ThroughputResolver.
+    _resolverCache.emplace("", make_unique<ThroughputResolver>(resolverCacheEntries));
+#else
+    // If we build in libcxx compatability mode, we need to use the default resolver.
+    // The ThroughputResolver currently does not build with libcxx.
+    _resolverCache.emplace("", make_unique<Resolver>(resolverCacheEntries));
+#endif
+}
+//---------------------------------------------------------------------------
+int32_t ConnectionManager::connect(string hostname, uint32_t port, bool tls, const TCPSettings& tcpSettings, bool useCache, int retryLimit)
+// Creates a new socket connection
+{
+    if (useCache) {
+        for (auto it = _fdCache.find(hostname); it != _fdCache.end(); it++) {
+            if (it->second->port == port && ((tls && it->second->tls.get()) || (!tls && !it->second->tls.get()))) {
+                auto fd = it->second->fd;
+                _fdSockets.emplace(fd, move(it->second));
+                _fdCache.erase(it);
+                return fd;
+            }
+        }
+    }
+
+    char port_str[16] = {};
+    sprintf(port_str, "%d", port);
+
+    Resolver* resCache;
+    auto tldName = string(Resolver::tld(hostname));
+    auto it = _resolverCache.find(tldName);
+    if (it != _resolverCache.end()) {
+        resCache = it->second.get();
+    } else {
+        resCache = _resolverCache.find("")->second.get();
+    }
+
+    // Did we use
+    bool oldAddress = false;
+    const auto* addr = resCache->resolve(hostname, port_str, oldAddress);
+
+    // Build socket
+    auto fd = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+    if (fd == -1) {
+        throw runtime_error("Socket creation error!" + string(strerror(errno)));
+    }
+
+    // Settings for socket
+    // No blocking mode
+    if (tcpSettings.nonBlocking > 0) {
+        int flags = fcntl(fd, F_GETFL, 0);
+        flags |= O_NONBLOCK;
+        if (fcntl(fd, F_SETFL, flags) < 0) {
+            throw runtime_error("Socket creation error! - non blocking error");
+        }
+    }
+
+    // Keep Alive
+    if (tcpSettings.keepAlive > 0) {
+        if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &tcpSettings.keepAlive, sizeof(tcpSettings.keepAlive))) {
+            throw runtime_error("Socket creation error! - keep alive error");
+        }
+    }
+
+    // Keep Idle
+    if (tcpSettings.keepIdle > 0) {
+        if (setsockopt(fd, SOL_TCP, TCP_KEEPIDLE, &tcpSettings.keepIdle, sizeof(tcpSettings.keepIdle))) {
+            throw runtime_error("Socket creation error! - keep idle error");
+        }
+    }
+
+    // Keep intvl
+    if (tcpSettings.keepIntvl > 0) {
+        if (setsockopt(fd, SOL_TCP, TCP_KEEPINTVL, &tcpSettings.keepIntvl, sizeof(tcpSettings.keepIntvl))) {
+            throw runtime_error("Socket creation error! - keep intvl error");
+        }
+    }
+
+    // Keep cnt
+    if (tcpSettings.keepCnt > 0) {
+        if (setsockopt(fd, SOL_TCP, TCP_KEEPCNT, &tcpSettings.keepCnt, sizeof(tcpSettings.keepCnt))) {
+            throw runtime_error("Socket creation error! - keep cnt error");
+        }
+    }
+
+    // No Delay
+    if (tcpSettings.noDelay > 0) {
+        if (setsockopt(fd, SOL_TCP, TCP_NODELAY, &tcpSettings.noDelay, sizeof(tcpSettings.noDelay))) {
+            throw runtime_error("Socket creation error! - nodelay error");
+        }
+    }
+
+    // Reuse ports
+    if (tcpSettings.reusePorts > 0) {
+        if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &tcpSettings.reusePorts, sizeof(tcpSettings.reusePorts))) {
+            throw runtime_error("Socket creation error! - reuse port error");
+        }
+    }
+
+    // Recv buffer
+    if (tcpSettings.recvBuffer > 0) {
+        if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &tcpSettings.recvBuffer, sizeof(tcpSettings.recvBuffer))) {
+            throw runtime_error("Socket creation error! - recvbuf error");
+        }
+    }
+
+    // Lingering of sockets
+    if (tcpSettings.linger > 0) {
+        if (setsockopt(fd, SOL_TCP, TCP_LINGER2, &tcpSettings.linger, sizeof(tcpSettings.linger))) {
+            throw runtime_error("Socket creation error - linger timeout error!" + string(strerror(errno)));
+        }
+    }
+
+    // TCP window shift
+#ifdef TCP_WINSHIFT
+    if (tcpSettings.windowShift && tcpSettings.recvBuffer >= (64 << 10)) {
+        int windowShift = 0;
+        for (int s = tcpSettings.recvBuffer >> 16; s > 0; s >>= 1) {
+            windowShift++;
+        }
+
+        if (setsockopt(inSock, SOL_TCP, TCP_WINSHIFT, &windowShift, sizeof(windowShift))) {
+            throw runtime_error("Socket creation error - win shift error!");
+        }
+    }
+#endif
+
+    // RFC 1323 optimization
+#ifdef TCP_RFC1323
+    if (tcpSettings.rfc1323 && tcpSettings.recvBuffer >= (64 << 10)) {
+        int on = 1;
+        if (setsockopt(fd, SOL_TCP, TCP_RFC1323, &on, sizeof(on))) {
+            throw runtime_error("Socket creation error - rfc 1323 error!");
+        }
+    }
+#endif
+
+    // Max segment size
+#ifdef TCP_MAXSEG
+    if (tcpSettings.mss > 0) {
+        if (setsockopt(fd, SOL_TCP, TCP_MAXSEG, &tcpSettings.mss, sizeof(tcpSettings.mss))) {
+            throw runtime_error("Socket creation error - max segment error!");
+        }
+    }
+#endif
+
+    auto setTimeOut = [](int fd, const TCPSettings& tcpSettings) {
+        // Set timeout
+        if (tcpSettings.timeout > 0) {
+            struct timeval tv;
+            tv.tv_sec = tcpSettings.timeout / (1000 * 1000);
+            tv.tv_usec = tcpSettings.timeout % (1000 * 1000);
+            if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&tv), sizeof tv)) {
+                throw runtime_error("Socket creation error - recv timeout error!");
+            }
+            if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char*>(&tv), sizeof tv)) {
+                throw runtime_error("Socket creation error - send timeout error!");
+            }
+            int timeoutInMs = tcpSettings.timeout / 1000;
+            if (setsockopt(fd, SOL_TCP, TCP_USER_TIMEOUT, &timeoutInMs, sizeof(timeoutInMs))) {
+                throw runtime_error("Socket creation error - tcp timeout error!" + string(strerror(errno)));
+            }
+        }
+    };
+
+    // Connect to remote
+    auto connectRes = ::connect(fd, addr->ai_addr, addr->ai_addrlen);
+    if (connectRes < 0 && errno != EINPROGRESS) {
+        close(fd);
+        if (oldAddress && retryLimit > 0) {
+            // Retry with a new address
+            resCache->resetBucket();
+            return connect(hostname, port, tls, tcpSettings, useCache, retryLimit - 1);
+        } else {
+            throw runtime_error("Socket creation error! " + string(strerror(errno)));
+        }
+    }
+
+    resCache->startSocket(fd);
+
+    auto emplaceSocket = [this, &hostname, port, tls](int32_t fd) {
+        if (tls)
+            _fdSockets.emplace(fd, make_unique<SocketEntry>(fd, hostname, port, make_unique<TLSConnection>(*_context)));
+        else
+            _fdSockets.emplace(fd, make_unique<SocketEntry>(fd, hostname, port, nullptr));
+    };
+
+    if (connectRes < 0 && errno == EINPROGRESS) {
+        // connection check
+        struct pollfd pollEvent;
+        pollEvent.fd = fd;
+        pollEvent.events = POLLIN | POLLOUT;
+
+        // connection check
+        auto t = poll(&pollEvent, 1, tcpSettings.timeout / 1000);
+        if (t == 1) {
+            int socketError;
+            socklen_t socketErrorLen = sizeof(socketError);
+            if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &socketError, &socketErrorLen)) {
+                throw runtime_error("Socket creation error! Could not retrieve socket options!");
+            }
+
+            if (!socketError) {
+                // sucessful
+                setTimeOut(fd, tcpSettings);
+                emplaceSocket(fd);
+                return fd;
+            } else {
+                close(fd);
+                throw runtime_error("Socket creation error! " + string(strerror(socketError)));
+            }
+        } else {
+            // Reached timeout
+            close(fd);
+            if (retryLimit > 0) {
+                return connect(hostname, port, tls, tcpSettings, useCache, retryLimit - 1);
+            } else {
+                throw runtime_error("Socket creation error! Timeout reached");
+            }
+        }
+    }
+    setTimeOut(fd, tcpSettings);
+    emplaceSocket(fd);
+    return fd;
+}
+//---------------------------------------------------------------------------
+void ConnectionManager::disconnect(int32_t fd, string hostname, uint32_t port, const TCPSettings* tcpSettings, uint64_t bytes, bool forceShutdown)
+// Disconnects the socket
+{
+    Resolver* resCache;
+    auto tldName = string(Resolver::tld(hostname));
+    auto it = _resolverCache.find(tldName);
+    if (it != _resolverCache.end()) {
+        resCache = it->second.get();
+    } else {
+        resCache = _resolverCache.find("")->second.get();
+    }
+    resCache->stopSocket(fd, bytes);
+    if (forceShutdown) {
+        shutdown(fd, SHUT_RDWR);
+        resCache->shutdownSocket(fd);
+    }
+    if (tcpSettings && tcpSettings->reuse > 0 && hostname.length() > 0 && port) {
+        auto it = _fdSockets.find(fd);
+        assert(it != _fdSockets.end());
+        _fdCache.emplace(hostname, move(it->second));
+        _fdSockets.erase(it);
+    } else {
+        _fdSockets.erase(fd);
+        close(fd);
+    }
+}
+//---------------------------------------------------------------------------
+void ConnectionManager::addResolver(const string& hostname, unique_ptr<Resolver> resolver)
+// Add resolver
+{
+    _resolverCache.emplace(string(Resolver::tld(hostname)), move(resolver));
+}
+//---------------------------------------------------------------------------
+bool ConnectionManager::checkTimeout(int fd, const TCPSettings& tcpSettings)
+// Check for a timeout
+{
+    pollfd p = {fd, POLLIN, 0};
+    int r = poll(&p, 1, tcpSettings.timeout / 1000);
+    if (r == 0) {
+        shutdown(fd, SHUT_RDWR);
+        return true;
+    }
+    return false;
+}
+//---------------------------------------------------------------------------
+TLSConnection* ConnectionManager::getTLSConnection(int32_t fd)
+// Get the tls connection of the fd
+{
+    auto it = _fdSockets.find(fd);
+    assert(it != _fdSockets.end());
+    return it->second->tls.get();
+}
+//---------------------------------------------------------------------------
+ConnectionManager::~ConnectionManager()
+// The destructor
+{
+    for (auto& f : _fdSockets)
+        close(f.first);
+    for (auto& f : _fdCache)
+        close(f.second->fd);
+}
+//---------------------------------------------------------------------------
+} // namespace network
+} // namespace anyblob

--- a/src/network/connection_manager.cpp
+++ b/src/network/connection_manager.cpp
@@ -277,8 +277,8 @@ void ConnectionManager::disconnect(int32_t fd, string hostname, uint32_t port, c
     if (forceShutdown) {
         shutdown(fd, SHUT_RDWR);
         resCache->shutdownSocket(fd);
-    }
-    if (tcpSettings && tcpSettings->reuse > 0 && hostname.length() > 0 && port) {
+        _fdSockets.erase(fd);
+    } else if (tcpSettings && tcpSettings->reuse > 0 && hostname.length() > 0 && port) {
         auto it = _fdSockets.find(fd);
         assert(it != _fdSockets.end());
         _fdCache.emplace(hostname, move(it->second));

--- a/src/network/http_message.cpp
+++ b/src/network/http_message.cpp
@@ -155,6 +155,9 @@ void HTTPMessage::reset(ConnectionManager& connectionManager, bool aborted)
     } else {
         originalMessage->result.state = MessageState::Aborted;
     }
+    if ((originalMessage->result.failureCode & static_cast<uint16_t>(MessageFailureCode::HTTP)) && originalMessage->provider.supportsResigning()) {
+        originalMessage->message = originalMessage->provider.resignRequest(*originalMessage->message, originalMessage->putData, originalMessage->putLength);
+    }
     connectionManager.disconnect(request->fd, originalMessage->provider.getAddress(), originalMessage->provider.getPort(), &tcpSettings, 0, true);
 }
 //---------------------------------------------------------------------------

--- a/src/network/http_request.cpp
+++ b/src/network/http_request.cpp
@@ -100,7 +100,8 @@ HttpRequest HttpRequest::deserialize(string_view data)
                         key = query.substr(0, keyPos);
                         value = query.substr(keyPos + 1);
                     }
-                    request.queries.emplace(key, value);
+                    if (key.size() > 0)
+                        request.queries.emplace(key, value);
                     if (queryPos == queries.npos)
                         break;
                     queries = queries.substr(queryPos + 1);

--- a/src/network/https_message.cpp
+++ b/src/network/https_message.cpp
@@ -40,8 +40,8 @@ MessageState HTTPSMessage::execute(ConnectionManager& connectionManager)
                 fd = connectionManager.connect(originalMessage->provider.getAddress(), originalMessage->provider.getPort(), true, tcpSettings);
             } catch (exception& /*e*/) {
                 originalMessage->result.failureCode |= static_cast<uint16_t>(MessageFailureCode::Socket);
-                state = MessageState::Aborted;
-                return state;
+                reset(connectionManager, failures++ > failuresMax);
+                return execute(connectionManager);
             }
             tlsLayer = connectionManager.getTLSConnection(fd);
             if (!tlsLayer->init(this)) {

--- a/src/network/message_task.cpp
+++ b/src/network/message_task.cpp
@@ -12,7 +12,7 @@ namespace network {
 //---------------------------------------------------------------------------
 using namespace std;
 //---------------------------------------------------------------------------
-MessageTask::MessageTask(OriginalMessage* message) : originalMessage(message), sendBufferOffset(0), receiveBufferOffset(0), failures(0)
+MessageTask::MessageTask(OriginalMessage* message, ConnectionManager::TCPSettings& tcpSettings, uint32_t chunkSize) : originalMessage(message), tcpSettings(tcpSettings), sendBufferOffset(0), receiveBufferOffset(0), chunkSize(chunkSize), failures(0)
 // The constructor
 {
 }

--- a/src/network/resolver.cpp
+++ b/src/network/resolver.cpp
@@ -42,7 +42,7 @@ Resolver::Resolver(unsigned entries)
     _addrCtr = 0;
 }
 //---------------------------------------------------------------------------
-unsigned Resolver::resolve(string hostname, string port, bool& oldAddress)
+const addrinfo* Resolver::resolve(string hostname, string port, bool& oldAddress)
 // Resolve the request
 {
     auto addrPos = _addrCtr % static_cast<unsigned>(_addrString.size());
@@ -64,7 +64,7 @@ unsigned Resolver::resolve(string hostname, string port, bool& oldAddress)
         _addrString[addrPos] = {move(hostString), 12};
         oldAddress = false;
     }
-    return addrPos;
+    return _addr[addrPos].get();
 }
 //---------------------------------------------------------------------------
 }; // namespace network

--- a/src/network/tasked_send_receiver.cpp
+++ b/src/network/tasked_send_receiver.cpp
@@ -287,7 +287,7 @@ void TaskedSendReceiver::sendReceive(bool local, bool oneQueueInvocation)
                     if (it->get() == task) {
                         // Remove the second param with the real data
                         if (_timings) {
-                            (*_timings)[task->originalMessage->traceId].size = task->originalMessage->result.getSize();
+                            (*_timings)[task->originalMessage->traceId].size = status == MessageState::Aborted ? 0 : task->originalMessage->result.getSize();
                             (*_timings)[task->originalMessage->traceId].finish = chrono::steady_clock::now();
                         }
 

--- a/src/network/tasked_send_receiver.cpp
+++ b/src/network/tasked_send_receiver.cpp
@@ -6,6 +6,7 @@
 #include "network/tls_context.hpp"
 #include "utils/data_vector.hpp"
 #include "utils/timer.hpp"
+#include "utils/utils.hpp"
 #include <algorithm>
 #include <cassert>
 #include <cstring>
@@ -17,12 +18,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 // SPDX-License-Identifier: MPL-2.0
-//---------------------------------------------------------------------------
-#ifndef NDEBUG
-#define verify(expression) assert(expression)
-#else
-#define verify(expression) ((void) (expression))
-#endif
 //---------------------------------------------------------------------------
 namespace anyblob {
 namespace network {
@@ -138,7 +133,7 @@ bool TaskedSendReceiverHandle::sendReceive(bool local, bool oneQueueInvocation)
     return true;
 }
 //---------------------------------------------------------------------------
-TaskedSendReceiver::TaskedSendReceiver(TaskedSendReceiverGroup& group) : _group(group), _submissions(), _next(nullptr), _connectionManager(make_unique<ConnectionManager>(group._concurrentRequests << 2, group._cacheEntries)), _messageTasks(), _timings(nullptr), _stopDeamon(false)
+TaskedSendReceiver::TaskedSendReceiver(TaskedSendReceiverGroup& group) : _group(group), _submissions(), _next(nullptr), _connectionManager(make_unique<ConnectionManager>(group._concurrentRequests << 2)), _messageTasks(), _timings(nullptr), _stopDeamon(false)
 // The constructor
 {
 }

--- a/src/network/tasked_send_receiver.cpp
+++ b/src/network/tasked_send_receiver.cpp
@@ -164,10 +164,10 @@ unique_ptr<utils::DataVector<uint8_t>> TaskedSendReceiver::getReused()
     return nullptr;
 }
 //--------------------------------------------------------------------------
-void TaskedSendReceiver::addResolver(const std::string& hostname, std::unique_ptr<Resolver> resolver)
-// Adds a resolver
+void TaskedSendReceiver::addCache(const std::string& hostname, std::unique_ptr<Cache> cache)
+// Adds a hostname-specific cache
 {
-    _connectionManager->addResolver(hostname, move(resolver));
+    _connectionManager->addCache(hostname, move(cache));
 }
 //--------------------------------------------------------------------------
 void TaskedSendReceiver::sendReceive(bool local, bool oneQueueInvocation)

--- a/src/network/throughput_cache.cpp
+++ b/src/network/throughput_cache.cpp
@@ -1,5 +1,5 @@
 #ifndef ANYBLOB_LIBCXX_COMPAT 
-#include "network/throughput_resolver.hpp"
+#include "network/throughput_cache.hpp"
 #include <cstring>
 #include <limits>
 #include <stdexcept>
@@ -19,13 +19,13 @@ namespace network {
 //---------------------------------------------------------------------------
 using namespace std;
 //---------------------------------------------------------------------------
-ThroughputResolver::ThroughputResolver(unsigned entries) : Resolver(entries), _throughputTree(), _throughput(), _throughputIterator()
+ThroughputCache::ThroughputCache(unsigned entries) : Cache(entries), _throughputTree(), _throughput(), _throughputIterator()
 // Constructor
 {
     _throughput.resize(_maxHistory);
 }
 //---------------------------------------------------------------------------
-const addrinfo* ThroughputResolver::resolve(string hostname, string port, bool& reuse)
+const addrinfo* ThroughputCache::resolve(string hostname, string port, bool& reuse)
 // Resolve the request
 {
     auto addrPos = _addrCtr % _addrString.size();
@@ -50,13 +50,13 @@ const addrinfo* ThroughputResolver::resolve(string hostname, string port, bool& 
     return _addr[addrPos].get();
 }
 //---------------------------------------------------------------------------
-void ThroughputResolver::startSocket(int fd)
+void ThroughputCache::startSocket(int fd)
 // Start a socket
 {
     _fdMap.emplace(fd, make_pair(_addrCtr++ % _addrString.size(), chrono::steady_clock::now()));
 }
 //---------------------------------------------------------------------------
-void ThroughputResolver::shutdownSocket(int fd)
+void ThroughputCache::shutdownSocket(int fd)
 // Shutdown a socket and clear the dns cache
 {
     auto it = _fdMap.find(fd);
@@ -71,7 +71,7 @@ void ThroughputResolver::shutdownSocket(int fd)
     }
 }
 //---------------------------------------------------------------------------
-void ThroughputResolver::stopSocket(int fd, uint64_t bytes)
+void ThroughputCache::stopSocket(int fd, uint64_t bytes)
 // Stop a socket
 {
     auto now = chrono::steady_clock::now();

--- a/src/network/throughput_resolver.cpp
+++ b/src/network/throughput_resolver.cpp
@@ -25,7 +25,7 @@ ThroughputResolver::ThroughputResolver(unsigned entries) : Resolver(entries), _t
     _throughput.resize(_maxHistory);
 }
 //---------------------------------------------------------------------------
-unsigned ThroughputResolver::resolve(string hostname, string port, bool& reuse)
+const addrinfo* ThroughputResolver::resolve(string hostname, string port, bool& reuse)
 // Resolve the request
 {
     auto modulo = static_cast<unsigned>(_addrString.size() < 8 ? _addrString.size() : 8);
@@ -48,17 +48,17 @@ unsigned ThroughputResolver::resolve(string hostname, string port, bool& reuse)
         reuse = false;
     }
     reuse = true;
-    return addrPos;
+    return _addr[addrPos].get();
 }
 //---------------------------------------------------------------------------
-void ThroughputResolver::startSocket(int fd, unsigned addrPos)
+void ThroughputResolver::startSocket(int fd)
 // Start a socket
 {
-    _fdMap.emplace(fd, make_pair(addrPos, chrono::steady_clock::now()));
+    _fdMap.emplace(fd, make_pair(_addrCtr++, chrono::steady_clock::now()));
 }
 //---------------------------------------------------------------------------
 void ThroughputResolver::shutdownSocket(int fd)
-// Start a socket
+// Shutdown a socket and clear the dns cache
 {
     auto it = _fdMap.find(fd);
     if (it != _fdMap.end()) {

--- a/src/network/tls_connection.cpp
+++ b/src/network/tls_connection.cpp
@@ -48,12 +48,10 @@ bool TLSConnection::init(HTTPSMessage* message)
         SSL_set_connect_state(_ssl);
         BIO_new_bio_pair(&_internalBio, _message->chunkSize, &_networkBio, _message->chunkSize);
         SSL_set_bio(_ssl, _internalBio, _internalBio);
-        // TODO: disable reuse for now
-        // _context.reuseSession(_message->fd, _ssl);
+         _context.reuseSession(_message->fd, _ssl);
     } else {
         _message = message;
         BIO_free(_networkBio);
-        BIO_free(_internalBio);
         BIO_new_bio_pair(&_internalBio, _message->chunkSize, &_networkBio, _message->chunkSize);
         SSL_set_bio(_ssl, _internalBio, _internalBio);
         _connected = true;

--- a/test/unit/cloud/aws_test.cpp
+++ b/test/unit/cloud/aws_test.cpp
@@ -55,6 +55,8 @@ class AWSTester {
         resultString += aws.fakeAMZTimestamp;
         resultString += "\r\nx-amz-request-payer: requester\r\nx-amz-security-token: ABC\r\n\r\n";
         REQUIRE(string_view(reinterpret_cast<char*>(dv->data()), dv->size()) == resultString);
+        auto dvResigned = aws.resignRequest(*dv.get());
+        REQUIRE(string_view(reinterpret_cast<char*>(dvResigned->data()), dvResigned->size()) == resultString);
 
         utils::DataVector<uint8_t> putData(10);
         dv = aws.putRequest("a/b/c.d", string_view(reinterpret_cast<const char*>(putData.data()), putData.size()));
@@ -62,12 +64,16 @@ class AWSTester {
         resultString += aws.fakeAMZTimestamp;
         resultString += "\r\nx-amz-request-payer: requester\r\nx-amz-security-token: ABC\r\n\r\n";
         REQUIRE(string_view(reinterpret_cast<char*>(dv->data()), dv->size()) == resultString);
+        dvResigned = aws.resignRequest(*dv.get(), putData.cdata(), putData.size());
+        REQUIRE(string_view(reinterpret_cast<char*>(dvResigned->data()), dvResigned->size()) == resultString);
 
         dv = aws.deleteRequest("a/b/c.d");
         resultString = "DELETE /a/b/c.d? HTTP/1.1\r\nAuthorization: AWS4-HMAC-SHA256 Credential=ABC/21000101/test/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-request-payer;x-amz-security-token, Signature=2240aba5140727498bd7bcea6f58e68a4c91ef2532b3273834a8d54983ae9319\r\nHost: test.s3.test.amazonaws.com\r\nx-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\nx-amz-date: ";
         resultString += aws.fakeAMZTimestamp;
         resultString += "\r\nx-amz-request-payer: requester\r\nx-amz-security-token: ABC\r\n\r\n";
         REQUIRE(string_view(reinterpret_cast<char*>(dv->data()), dv->size()) == resultString);
+        dvResigned = aws.resignRequest(*dv.get());
+        REQUIRE(string_view(reinterpret_cast<char*>(dvResigned->data()), dvResigned->size()) == resultString);
 
         auto vec = AWSInstance::getInstanceDetails();
         REQUIRE(vec.size() > 0);

--- a/test/unit/network/io_uring_socket_test.cpp
+++ b/test/unit/network/io_uring_socket_test.cpp
@@ -1,6 +1,6 @@
 #include "catch2/single_include/catch2/catch.hpp"
 #include "cloud/aws_resolver.hpp"
-#include "network/io_uring_socket.hpp"
+#include "network/connection_manager.hpp"
 #include "perfevent/PerfEvent.hpp"
 //---------------------------------------------------------------------------
 // AnyBlob - Universal Cloud Object Storage Library
@@ -16,9 +16,9 @@ namespace test {
 //---------------------------------------------------------------------------
 TEST_CASE("io_uring_socket") {
     PerfEventBlock e;
-    IOUringSocket io(10, 0);
-    IOUringSocket::TCPSettings tcpSettings;
-    REQUIRE(io.connect("db.in.tum.de", 80, tcpSettings) > 0);
+    ConnectionManager io (10, 10);
+    ConnectionManager::TCPSettings tcpSettings;
+    REQUIRE(io.connect("db.in.tum.de", 80, false, tcpSettings) > 0);
 }
 //---------------------------------------------------------------------------
 } // namespace test

--- a/test/unit/network/io_uring_socket_test.cpp
+++ b/test/unit/network/io_uring_socket_test.cpp
@@ -16,7 +16,7 @@ namespace test {
 //---------------------------------------------------------------------------
 TEST_CASE("io_uring_socket") {
     PerfEventBlock e;
-    ConnectionManager io (10, 10);
+    ConnectionManager io (10);
     ConnectionManager::TCPSettings tcpSettings;
     REQUIRE(io.connect("db.in.tum.de", 80, false, tcpSettings) > 0);
 }

--- a/test/unit/network/io_uring_socket_test.cpp
+++ b/test/unit/network/io_uring_socket_test.cpp
@@ -1,5 +1,5 @@
 #include "catch2/single_include/catch2/catch.hpp"
-#include "cloud/aws_resolver.hpp"
+#include "cloud/aws_cache.hpp"
 #include "network/connection_manager.hpp"
 #include "perfevent/PerfEvent.hpp"
 //---------------------------------------------------------------------------

--- a/test/unit/network/resolver_test.cpp
+++ b/test/unit/network/resolver_test.cpp
@@ -1,4 +1,4 @@
-#include "network/resolver.hpp"
+#include "network/cache.hpp"
 #include "catch2/single_include/catch2/catch.hpp"
 //---------------------------------------------------------------------------
 // AnyBlob - Universal Cloud Object Storage Library
@@ -12,7 +12,7 @@ namespace anyblob {
 namespace network {
 namespace test {
 //---------------------------------------------------------------------------
-TEST_CASE("resolver") {
+TEST_CASE("cache") {
 }
 //---------------------------------------------------------------------------
 } // namespace test

--- a/test/unit/network/send_receiver_test.cpp
+++ b/test/unit/network/send_receiver_test.cpp
@@ -1,6 +1,6 @@
 #include "catch2/single_include/catch2/catch.hpp"
-#include "cloud/provider.hpp"
 #include "cloud/http.hpp"
+#include "cloud/provider.hpp"
 #include "network/original_message.hpp"
 #include "network/tasked_send_receiver.hpp"
 #include "perfevent/PerfEvent.hpp"
@@ -29,6 +29,7 @@ using namespace std;
 TEST_CASE("send_receiver") {
     PerfEventBlock e;
     auto concurrency = 8u;
+    auto requests = 64u;
 
     TaskedSendReceiverGroup group;
     group.setConcurrentRequests(concurrency);
@@ -36,9 +37,8 @@ TEST_CASE("send_receiver") {
     auto provider = cloud::Provider::makeProvider("http://db.cs.tum.edu");
     auto tlsProvider = cloud::Provider::makeProvider("https://db.cs.tum.edu");
 
-
     vector<unique_ptr<OriginalMessage>> msgs;
-    for (auto i = 0u; i < concurrency; i++) {
+    for (auto i = 0u; i < requests; i++) {
         auto range = std::pair<uint64_t, uint64_t>(0, 0);
         string file = "";
         msgs.emplace_back(new OriginalMessage{provider->getRequest(file, range), *provider});


### PR DESCRIPTION
This PR is breaking some existing APIs!

The main features include:

1. Redesign the caching infrastructure to attach fds to dns entries
2. Attach tls connections to fds, to reuse running tls connection (avoid additional handshakes)
3. Better error reporting to the user if provider answers with HttpResponse
4. Allow message resigning with the original provider (e.g., AWS keys have lifetime and it can be necessary to resign a message)
5. Avoid lifelock issues with sendAsync and few open ringbuffer places
6. Various smaller fixes