### PR TITLE
Restrict number of cached elements

### DIFF
--- a/example/benchmark/scripts/create.sh
+++ b/example/benchmark/scripts/create.sh
@@ -14,19 +14,20 @@ fi
 aws s3api create-bucket --bucket $CONTAINER --region $REGION --create-bucket-configuration LocationConstraint=$REGION
 #------------------------------------------------------
 mkdir data
+mkdir data/enc
 cd data
 for size in ${SIZES[@]}
 do
     for n in {1..8192}
     do
         openssl rand -out ${n}.bin $size
-        openssl enc -aes-256-cbc -K "3031323334353637383930313233343536373839303132333435363738393031" -iv "30313233343536373839303132333435" -in ${n}.bin -out ${n}.enc.bin
+        openssl enc -aes-256-cbc -K "3031323334353637383930313233343536373839303132333435363738393031" -iv "30313233343536373839303132333435" -in ${n}.bin -out enc/${n}.bin
     done
     aws s3 sync ./ s3://${CONTAINER}/${size}/
     for n in {1..8192}
     do
         rm ${n}.bin
-        rm ${n}.enc.bin
+        rm enc/${n}.bin
     done
 done
 #------------------------------------------------------

--- a/include/network/cache.hpp
+++ b/include/network/cache.hpp
@@ -42,6 +42,8 @@ class Cache {
         std::unique_ptr<DnsEntry> dns;
         /// The optional tls connection
         std::unique_ptr<TLSConnection> tls;
+        /// The timestamp
+        size_t timestamp;
         /// The fd
         int32_t fd;
         /// The port
@@ -57,6 +59,10 @@ class Cache {
     protected:
     /// The cache, uses hostname as key, multimap traversals same keys in the insertion order
     std::multimap<std::string, std::unique_ptr<SocketEntry>> _cache;
+    /// The fifo deletion of sockets to help reduce open fds (ulimit -n issue)
+    std::map<size_t, SocketEntry*> _fifo;
+    /// The timestamp counter for deletion
+    size_t _timestamp = 0;
     /// The default priority
     int _defaultPriority = 8;
 
@@ -68,7 +74,7 @@ class Cache {
     /// Stops the socket and either closes the connection or cashes it
     virtual void stopSocket(std::unique_ptr<SocketEntry> socketEntry, uint64_t bytes, unsigned cachedEntries, bool reuseSocket);
     /// Shutdown of the socket and clears the same addresses
-    virtual void shutdownSocket(std::unique_ptr<SocketEntry> socketEntry);
+    virtual void shutdownSocket(std::unique_ptr<SocketEntry> socketEntry, unsigned cachedEntries);
     /// The destructor
     virtual ~Cache();
 


### PR DESCRIPTION
Restrict the number of open file requests. This is important if multiple different hostnames need to be cached, as the cache entries cannot be reused for different hostnames and the cache would be growing otherwise.