### PR TITLE
Set cloud provider to HTTPS in RemoteInfo in AWS provider init code.

### DIFF
--- a/src/cloud/aws.cpp
+++ b/src/cloud/aws.cpp
@@ -63,6 +63,7 @@ Provider::Instance AWS::getInstanceDetails(network::TaskedSendReceiverHandle& se
         RemoteInfo info;
         info.endpoint = getIAMAddress();
         info.port = getIAMPort();
+        info.provider = Provider::CloudService::HTTPS;
         HTTP http(info);
         auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
         verify(sendReceiverHandle.sendSync(originalMsg.get()));
@@ -87,6 +88,7 @@ string AWS::getInstanceRegion(network::TaskedSendReceiverHandle& sendReceiverHan
     RemoteInfo info;
     info.endpoint = getIAMAddress();
     info.port = getIAMPort();
+    info.provider = Provider::CloudService::HTTPS;
     HTTP http(info);
     auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
     verify(sendReceiverHandle.sendSync(originalMsg.get()));
@@ -245,6 +247,7 @@ void AWS::initSecret(network::TaskedSendReceiverHandle& sendReceiverHandle)
                 RemoteInfo info;
                 info.endpoint = getIAMAddress();
                 info.port = getIAMPort();
+                info.provider = Provider::CloudService::HTTPS;
                 HTTP http(info);
                 auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
                 verify(sendReceiverHandle.sendSync(originalMsg.get()));
@@ -280,6 +283,7 @@ void AWS::initSecret(network::TaskedSendReceiverHandle& sendReceiverHandle)
                 RemoteInfo info;
                 info.endpoint = _settings.bucket + ".s3.amazonaws.com";
                 info.port = getPort();
+                info.provider = Provider::CloudService::HTTPS;
                 HTTP http(info);
                 auto originalMsg = make_unique<network::OriginalMessage>(move(message), http);
                 verify(sendReceiverHandle.sendSync(originalMsg.get()));


### PR DESCRIPTION
When you run Anyblob on EC2 in AWS and specify the connection URL for Provider initialization as `s3://...` but leave credentials empty - the code reaches into EC2 metadata service to try to get credentials. There are 4 places where HTTP requests are made. I'll mention specifically lines that cause problems - where the HTTP Provider is initialized to make those requests. 
https://github.com/durner/AnyBlob/blob/master/src/cloud/aws.cpp#L66
https://github.com/durner/AnyBlob/blob/master/src/cloud/aws.cpp#L90
https://github.com/durner/AnyBlob/blob/master/src/cloud/aws.cpp#L248
https://github.com/durner/AnyBlob/blob/master/src/cloud/aws.cpp#L283

The problem is in HTTP provider constructor:
https://github.com/durner/AnyBlob/blob/master/include/cloud/http.hpp#L39
This line's assertion always fails, because `info.provider` is not initialised.

In this PR I add initialisation for `info.provider`.