### PR TITLE
[HOTFIX] Fix uninitialized warning in send_receiver_test.cpp

### DIFF
--- a/test/unit/network/send_receiver_test.cpp
+++ b/test/unit/network/send_receiver_test.cpp
@@ -49,7 +49,7 @@ TEST_CASE("send_receiver") {
     group.process(true);
 
     unique_ptr<uint8_t[]> currentMessage;
-    size_t skip;
+    size_t skip = 0u;
     for (auto i = 0u; i < msgs.size();) {
         auto& original = msgs[i];
         switch (original->result.getState()) {


### PR DESCRIPTION
Hey, thanks for sharing the code online!

Wanted to try it out, and everything works very smoothly except for a warning that leads to an error given the `-Werror` setting. Submitting a quick one-liner fix here.

Error log:
```
.../AnyBlob/test/unit/network/send_receiver_test.cpp: In function ‘void anyblob::network::test::C_A_T_C_H_T_E_S_T_0()’:
.../AnyBlob/test/unit/network/send_receiver_test.cpp:60:37: error: ‘skip’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   60 |                     REQUIRE(!strncmp(reinterpret_cast<char*>(currentMessage.get()) + skip, reinterpret_cast<char*>(message.getData()) + message.getOffset(), message.getSize()));
      |                                     ^
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-unqualified-std-cast-call’ may have been intended to silence earlier diagnostics
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/tester.dir/build.make:202: CMakeFiles/tester.dir/test/unit/network/send_receiver_test.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:113: CMakeFiles/tester.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....

```

Let me know if this acceptable or you'd like me to make additional changes!